### PR TITLE
Use latest sqlds

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,13 +2,10 @@ module github.com/grafana/redshift-datasource
 
 go 1.16
 
-// pointing to a local package until this PR is merged: https://github.com/grafana/sqlds/pull/17
-replace github.com/grafana/sqlds => ../../sqlds
-
 require (
 	github.com/aws/aws-sdk-go v1.38.54
 	github.com/grafana/grafana-aws-sdk v0.6.0
 	github.com/grafana/grafana-plugin-sdk-go v0.104.0
-	github.com/grafana/sqlds v1.0.11 // indirect
+	github.com/grafana/sqlds v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -146,6 +146,8 @@ github.com/grafana/grafana-plugin-sdk-go v0.104.0 h1:Ij2tPdEasSjCb2MxHaaiylyW4RL
 github.com/grafana/grafana-plugin-sdk-go v0.104.0/go.mod h1:D7x3ah+1d4phNXpbnOaxa/osSaZlwh9/ZUnGGzegRbk=
 github.com/grafana/sqlds v1.0.11 h1:ir0g3R9hRF+YFExvJ790Q2RFAosGMtiCFSn35mGt+DM=
 github.com/grafana/sqlds v1.0.11/go.mod h1:YAUp48fa9P65GPkbyjlPWAAkcipS4ksx/QsVqw5Gs/k=
+github.com/grafana/sqlds v1.1.0 h1:hdyOeyld/qUoI/E+l4xG8VwN6S2DXHJdzYED6CfuI8U=
+github.com/grafana/sqlds v1.1.0/go.mod h1:YAUp48fa9P65GPkbyjlPWAAkcipS4ksx/QsVqw5Gs/k=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.0/go.mod h1:mJzapYve32yjrKlk9GbyCZHuPgZsrbyIbyKhSzOpg6s=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=


### PR DESCRIPTION
Now that [this](https://github.com/grafana/sqlds/pull/17) PR is merged and released, let's replace local sqlds package with a proper release.