### PR TITLE
Replace text area with monaco code editor

### DIFF
--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -29,7 +29,7 @@ export class QueryEditor extends PureComponent<Props> {
         <CodeEditor
           height={'250px'}
           language="redshift"
-          value={rawSQL || ''}
+          value={rawSQL}
           onBlur={this.onRawSqlChange}
           onSave={this.onRawSqlChange}
           showMiniMap={false}


### PR DESCRIPTION
This PR replaces the text area in the frontend with CodeEditor component from grafana ui. Fortunately, there is a already a monaco language for [aws redshift](https://github.com/microsoft/monaco-languages/blob/main/src/redshift/redshift.ts). 

FYI, there's a separate issue for providing suggestions to the editor. https://github.com/grafana/redshift-datasource/issues/16

Any thoughts on how to unit test the CodeEditor @joshhunt? Soon we'll add e2e tests to this data source, and then we'll add scenarios that add queries to the code editor. Maybe that will be sufficient? 

Fixes #17 