### PR TITLE
Add CI and fix lint issues

### DIFF
--- a/pkg/redshift/driver/mock_redshift_service.go
+++ b/pkg/redshift/driver/mock_redshift_service.go
@@ -44,12 +44,7 @@ var twoRecords = [][]*redshiftdataapiservice.Field{
 }
 
 type mockRedshiftService struct {
-	getStatementResult *redshiftdataapiservice.GetStatementResultOutput
 	pageCounter        int
-}
-
-func newMockRedshiftService() *mockRedshiftService {
-	return &mockRedshiftService{pageCounter: 0}
 }
 
 func (s *mockRedshiftService) GetStatementResult(input *redshiftdataapiservice.GetStatementResultInput) (*redshiftdataapiservice.GetStatementResultOutput, error) {

--- a/pkg/redshift/driver/rows_test.go
+++ b/pkg/redshift/driver/rows_test.go
@@ -13,10 +13,9 @@ func TestOnePageSuccess(t *testing.T) {
 	rows, rowErr := newRows(redshiftServiceMock, singlePageResponseQueryId)
 	require.NoError(t, rowErr)
 	cnt := 0
-	var err error = nil
 	for {
 		var col1, col2 string
-		err = rows.Next([]driver.Value{
+		err := rows.Next([]driver.Value{
 			&col1,
 			&col2,
 		})
@@ -35,10 +34,9 @@ func TestMultiPageSuccess(t *testing.T) {
 	rows, rowErr := newRows(redshiftServiceMock, multiPageResponseQueryId)
 	require.NoError(t, rowErr)
 	cnt := 0
-	var err error = nil
 	for {
 		var col1, col2 string
-		err = rows.Next([]driver.Value{
+		err := rows.Next([]driver.Value{
 			&col1,
 			&col2,
 		})


### PR DESCRIPTION
 This PR enables backend plugin build in drone and it also addresses this issues that was found when running the build. 

**How to enable the build?**
I had to go into https://drone.grafana.net/grafana/redshift-datasource/settings and click `activate`. Then I changed to configuration field to point to `src/plugin.json`.

**How does it work?** 
We have a custom built [drone extension](https://github.com/grafana/grafana-drone-extension/) that handles the build. When activated, this will read config from plugin.json and execute each separate build step according to [this](https://github.com/grafana/grafana-drone-extension/blob/master/pluginjson/pipeline-ci.go) file. 

The artifacts are stored [here](https://console.cloud.google.com/storage/browser/plugins-ci/drone/grafana/redshift-datasource?pageState=(%22StorageObjectListTable%22:(%22f%22:%22%255B%255D%22))&project=grafanalabs-global&prefix=&forceOnObjectsSortingFiltering=false)

Fixes #20 