### PR TITLE
Add support for template variables

### DIFF
--- a/src/__mocks__/datasource.ts
+++ b/src/__mocks__/datasource.ts
@@ -1,0 +1,34 @@
+import { PluginType } from '@grafana/data';
+import { RedshiftQuery } from '../types';
+import { DataSource } from '../datasource';
+
+export const mockDatasource = new DataSource({
+  id: 1,
+  uid: 'redshift-id',
+  type: 'redshift-datasource',
+  name: 'Redshift Data Source',
+  jsonData: {},
+  meta: {
+    id: 'redshift-datasource',
+    name: 'Redshift Data Source',
+    type: PluginType.datasource,
+    module: '',
+    baseUrl: '',
+    info: {
+      description: '',
+      screenshots: [],
+      updated: '',
+      version: '',
+      logos: {
+        small: '',
+        large: '',
+      },
+      author: {
+        name: '',
+      },
+      links: [],
+    },
+  },
+});
+
+export const mockQuery: RedshiftQuery = { rawSQL: 'select * from foo', refId: '', format: 0 };

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -1,0 +1,16 @@
+import * as runtime from '@grafana/runtime';
+import { mockDatasource, mockQuery } from './__mocks__/datasource';
+
+describe('DataSource', () => {
+  describe('applyTemplateVariables', () => {
+    const replace = jest.fn();
+    beforeEach(() => {
+      jest.spyOn(runtime, 'getTemplateSrv').mockImplementation(() => ({ getVariables: jest.fn(), replace }));
+    });
+    it('applyTemplateVariables - query', () => {
+      mockDatasource.applyTemplateVariables({ ...mockQuery, rawSQL: 'select * from bar' }, {});
+      expect(replace).toBeCalledTimes(1);
+      expect(replace).nthCalledWith(1, 'select * from bar', {}, 'singlequote');
+    });
+  });
+});

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,9 +1,18 @@
-import { DataSourceInstanceSettings } from '@grafana/data';
-import { DataSourceWithBackend } from '@grafana/runtime';
+import { DataSourceInstanceSettings, ScopedVars } from '@grafana/data';
+import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 import { RedshiftDataSourceOptions, RedshiftQuery } from './types';
 
 export class DataSource extends DataSourceWithBackend<RedshiftQuery, RedshiftDataSourceOptions> {
   constructor(instanceSettings: DataSourceInstanceSettings<RedshiftDataSourceOptions>) {
     super(instanceSettings);
+  }
+
+  applyTemplateVariables(query: RedshiftQuery, scopedVars: ScopedVars): RedshiftQuery {
+    const templateSrv = getTemplateSrv();
+
+    return {
+      ...query,
+      rawSQL: templateSrv.replace(query.rawSQL, scopedVars, 'singlequote'),
+    };
   }
 }


### PR DESCRIPTION
This PR adds support for template variables. 

Unfortunately, the template variables service is not exposed to external plugins. Had it been it would have been possible to initialize it with custom variables (like in [this](https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/grafana-azure-monitor-datasource/azure_resource_graph/azure_resource_graph_datasource.test.ts) example in core grafana). 

Closes #22 