### PR TITLE
Implement some macros

### DIFF
--- a/pkg/redshift/datasource.go
+++ b/pkg/redshift/datasource.go
@@ -10,7 +10,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
 	"github.com/grafana/redshift-datasource/pkg/redshift/driver"
 	"github.com/grafana/redshift-datasource/pkg/redshift/models"
-	"github.com/grafana/sqlds"
 	"github.com/pkg/errors"
 )
 
@@ -56,8 +55,4 @@ func (s *RedshiftDatasource) Converters() (sc []sqlutil.Converter) {
 			},
 		},
 	}}
-}
-
-func (s *RedshiftDatasource) Macros() sqlds.Macros {
-	return nil
 }

--- a/pkg/redshift/macros.go
+++ b/pkg/redshift/macros.go
@@ -1,0 +1,51 @@
+package redshift
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/grafana/sqlds"
+	"github.com/pkg/errors"
+)
+
+func macroTimeFilter(query *sqlds.Query, args []string) (string, error) {
+	if len(args) != 1 {
+		return "", errors.WithMessagef(sqlds.ErrorBadArgumentCount, "expected 1 argument, received %d", len(args))
+	}
+
+	var (
+		column = args[0]
+		from   = query.TimeRange.From.UTC().Format(time.RFC3339)
+		to     = query.TimeRange.To.UTC().Format(time.RFC3339)
+	)
+
+	return fmt.Sprintf("%s BETWEEN '%s' AND '%s'", column, from, to), nil
+}
+
+func macroTimeFrom(query *sqlds.Query, args []string) (string, error) {
+	return fmt.Sprintf("'%s'", query.TimeRange.From.UTC().Format(time.RFC3339)), nil
+
+}
+
+func macroTimeTo(query *sqlds.Query, args []string) (string, error) {
+	return fmt.Sprintf("'%s'", query.TimeRange.To.UTC().Format(time.RFC3339)), nil
+}
+
+func macroTimeGroup(query *sqlds.Query, args []string) (string, error) {
+	if len(args) < 2 {
+		return "", errors.WithMessagef(sqlds.ErrorBadArgumentCount, "macro timeGroup expects 2 arguments, received %d", len(args))
+	}
+
+	return fmt.Sprintf("date_trunc(%s, %s)", args[1], args[0]), nil
+}
+
+var macros = map[string]sqlds.MacroFunc{
+	"timeFilter": macroTimeFilter,
+	"timeFrom":   macroTimeFrom,
+	"timeTo":     macroTimeTo,
+	"timeGroup":  macroTimeGroup,
+}
+
+func (s *RedshiftDatasource) Macros() sqlds.Macros {
+	return macros
+}

--- a/pkg/redshift/macros_test.go
+++ b/pkg/redshift/macros_test.go
@@ -1,0 +1,96 @@
+package redshift
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/sqlds"
+	"github.com/pkg/errors"
+)
+
+func Test_macros(t *testing.T) {
+	tests := []struct {
+		description string
+		macro       string
+		query       *sqlds.Query
+		args        []string
+		expected    string
+		expectedErr error
+	}{
+		{
+			"creates time filter",
+			"timeFilter",
+			&sqlds.Query{
+				TimeRange: backend.TimeRange{
+					From: time.Date(2021, 6, 23, 0, 0, 0, 0, &time.Location{}),
+					To:   time.Date(2021, 6, 23, 1, 0, 0, 0, &time.Location{}),
+				},
+			},
+			[]string{"starttime"},
+			`starttime BETWEEN '2021-06-23T00:00:00Z' AND '2021-06-23T01:00:00Z'`,
+			nil,
+		},
+		{
+			"wrong args for time filter",
+			"timeFilter",
+			&sqlds.Query{},
+			[]string{},
+			"",
+			sqlds.ErrorBadArgumentCount,
+		},
+		{
+			"creates time from filter",
+			"timeFrom",
+			&sqlds.Query{
+				TimeRange: backend.TimeRange{
+					From: time.Date(2021, 6, 23, 0, 0, 0, 0, &time.Location{}),
+					To:   time.Date(2021, 6, 23, 1, 0, 0, 0, &time.Location{}),
+				},
+			},
+			[]string{},
+			`'2021-06-23T00:00:00Z'`,
+			nil,
+		},
+		{
+			"creates time to filter",
+			"timeTo",
+			&sqlds.Query{
+				TimeRange: backend.TimeRange{
+					From: time.Date(2021, 6, 23, 0, 0, 0, 0, &time.Location{}),
+					To:   time.Date(2021, 6, 23, 1, 0, 0, 0, &time.Location{}),
+				},
+			},
+			[]string{},
+			`'2021-06-23T01:00:00Z'`,
+			nil,
+		},
+		{
+			"creates time group",
+			"timeGroup",
+			&sqlds.Query{},
+			[]string{"starttime", "'day'"},
+			`date_trunc('day', starttime)`,
+			nil,
+		},
+		{
+			"wrong args for time group",
+			"timeGroup",
+			&sqlds.Query{},
+			[]string{},
+			"",
+			sqlds.ErrorBadArgumentCount,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.description, func(t *testing.T) {
+			res, err := macros[tt.macro](tt.query, tt.args)
+			if (err != nil || tt.expectedErr != nil) && !errors.Is(err, tt.expectedErr) {
+				t.Errorf("unexpected error %v, expecting %v", err, tt.expectedErr)
+			}
+			if res != tt.expected {
+				t.Errorf("unexpected result %v, expecting %v", res, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #25 

Added some basic macros:
 - `$__timeFilter(column)`: Used to get the time period of the current interval
 - `$__timeFrom()`: Returns the current starting value of the time range
 - `$__timeTo()`: Returns the current ending value of the time range
 - `$__timeGroup(column, period)`: Truncates the given period from the column. Note that this is a different approach than [the one used in postgres](https://github.com/grafana/grafana/blob/main/pkg/tsdb/postgres/macros.go#L111). Using `floor(extract(epoch` returns a number that as far as I know cannot be converted back to a timestamp. Instead, I am using the approach suggested [here](https://popsql.com/learn-sql/redshift/how-to-group-by-time-in-redshift) and in this [issue](https://github.com/grafana/grafana/issues/11578).

Here is a working example:
![Screenshot from 2021-06-23 12-26-48](https://user-images.githubusercontent.com/4025665/123082979-e40c0600-d41f-11eb-8d2a-0f230eb71727.png)


