### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@v2
         with:
-          go-version: "1.15"
+          go-version: "1.16"
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path


### PR DESCRIPTION
Use the same version than in the CI: https://github.com/grafana/redshift-datasource/blob/main/.github/workflows/ci.yml#L61

Likely this is what's causing the error at https://github.com/grafana/redshift-datasource/runs/2930891793#step:12:20