### PR TITLE
Add NAME data type

### DIFF
--- a/pkg/redshift/driver/redshift.go
+++ b/pkg/redshift/driver/redshift.go
@@ -25,4 +25,5 @@ const (
 	REDSHIFT_GEOMETRY                 = "GEOMETRY"
 	REDSHIFT_HLLSKETCH                = "HLLSKETCH"
 	REDSHIFT_SUPER                    = "SUPER"
+	REDSHIFT_NAME                     = "NAME"
 )

--- a/pkg/redshift/driver/rows.go
+++ b/pkg/redshift/driver/rows.go
@@ -234,7 +234,8 @@ func convertRow(columns []*redshiftdataapiservice.ColumnMetadata, data []*redshi
 			// Complex types are returned as a string
 			REDSHIFT_GEOMETRY,
 			REDSHIFT_HLLSKETCH,
-			REDSHIFT_SUPER:
+			REDSHIFT_SUPER,
+			REDSHIFT_NAME:
 			ret[i] = *curr.StringValue
 		// Time formats from
 		// https://docs.aws.amazon.com/redshift/latest/dg/r_Datetime_types.html

--- a/pkg/redshift/driver/rows_test.go
+++ b/pkg/redshift/driver/rows_test.go
@@ -340,6 +340,18 @@ func Test_convertRow(t *testing.T) {
 			expectedValue: `{"foo":"bar"}`,
 			Err:           require.NoError,
 		},
+		{
+			name: "name",
+			metadata: &redshiftdataapiservice.ColumnMetadata{
+				TypeName: aws.String(REDSHIFT_NAME),
+			},
+			data: &redshiftdataapiservice.Field{
+				StringValue: aws.String(`table`),
+			},
+			expectedType:  "string",
+			expectedValue: `table`,
+			Err:           require.NoError,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Redshift data types are documented here: https://docs.aws.amazon.com/redshift/latest/dg/c_Supported_data_types.html

But I actually found out, when retrieving table names of the Redshift database, that these names are of the type `NAME`. This is not documented :shrug: but it's just a string.

