### PR TITLE
Use SQL language in the query editor

### DIFF
--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -6,7 +6,7 @@ import { DataSource } from './datasource';
 import { defaultQuery, RedshiftDataSourceOptions, RedshiftQuery, SelectableFormatOptions } from './types';
 import { CodeEditor, Alert, InlineField, Select } from '@grafana/ui';
 import { SchemaInfo } from 'SchemaInfo';
-import { getTemplateSrv } from '@grafana/runtime';
+import { getTemplateSrv, config } from '@grafana/runtime';
 
 type Props = QueryEditorProps<DataSource, RedshiftQuery, RedshiftDataSourceOptions>;
 
@@ -33,7 +33,7 @@ export function QueryEditor(props: Props) {
       <CodeEditor
         height={'250px'}
         // TODO: Use language="redshift" once Grafana v7.x is deprecated.
-        language="sql"
+        language={config.buildInfo.version.startsWith('7.5') ? 'sql' : 'redshift'}
         value={rawSQL}
         onBlur={onRawSqlChange}
         onSave={onRawSqlChange}


### PR DESCRIPTION
The language `redshift` is not available in the Monaco editor version bundled with Grafana 7.5, causing the auto completion and syntax highlight not to work. The `sql` language is present in both 7.5 and 8.0.