### PR TITLE
Increase Polling Interval

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/grafana/grafana-aws-sdk v0.6.0
 	github.com/grafana/grafana-plugin-sdk-go v0.104.0
 	github.com/grafana/sqlds v1.2.0
+	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/mattn/go-runewidth v0.0.10 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -181,6 +181,7 @@ github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHW
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2EA=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/pkg/redshift/driver/connection_test.go
+++ b/pkg/redshift/driver/connection_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	redshiftservicemock "github.com/grafana/redshift-datasource/pkg/redshift/driver/mock"
+	"github.com/jpillora/backoff"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -14,27 +15,26 @@ var waitOnQueryTestCases = []struct {
 	calledTimesCountDown int
 	statementStatus      string
 	err                  error
-	minDuration          int
 }{
-	{1, redshiftservicemock.DESCRIBE_STATEMENT_SUCCEEDED, nil, 0},
-	{2, redshiftservicemock.DESCRIBE_STATEMENT_SUCCEEDED, nil, 1},
-	{3, redshiftservicemock.DESCRIBE_STATEMENT_SUCCEEDED, nil, 1 + 1},
-	{4, redshiftservicemock.DESCRIBE_STATEMENT_FAILED, fmt.Errorf(redshiftservicemock.DESCRIBE_STATEMENT_FAILED), 1 + 1 + 2},
-	{5, redshiftservicemock.DESCRIBE_STATEMENT_FAILED, fmt.Errorf(redshiftservicemock.DESCRIBE_STATEMENT_FAILED), 1 + 1 + 2 + 3},
-	{6, redshiftservicemock.DESCRIBE_STATEMENT_FAILED, fmt.Errorf(redshiftservicemock.DESCRIBE_STATEMENT_FAILED), 1 + 1 + 2 + 3 + 5},
+	{1, redshiftservicemock.DESCRIBE_STATEMENT_SUCCEEDED, nil},
+	{10, redshiftservicemock.DESCRIBE_STATEMENT_SUCCEEDED, nil},
+	{1, redshiftservicemock.DESCRIBE_STATEMENT_FAILED, fmt.Errorf(redshiftservicemock.DESCRIBE_STATEMENT_FAILED)},
+	{10, redshiftservicemock.DESCRIBE_STATEMENT_FAILED, fmt.Errorf(redshiftservicemock.DESCRIBE_STATEMENT_FAILED)},
 }
 
 func TestConnection_waitOnQuery(t *testing.T) {
 	t.Parallel()
+
 	for _, tc := range waitOnQueryTestCases {
-		c := newConnection(nil, nil)
+		// for tests we override backoff instance to always take 1 millisecond so the tests run quickly
+		c := &conn{backoffInstance: backoff.Backoff{
+			Min:    1 * time.Millisecond,
+			Max:   1 * time.Millisecond,
+		},}
 		redshiftServiceMock := redshiftservicemock.NewMockRedshiftService()
 		redshiftServiceMock.CalledTimesCountDown = tc.calledTimesCountDown
-		beforeCall := time.Now()
 		err := c.waitOnQuery(context.Background(), redshiftServiceMock, tc.statementStatus)
-		durationOfCall := time.Since(beforeCall)
 		assert.Equal(t, tc.err, err)
 		assert.Equal(t, tc.calledTimesCountDown, redshiftServiceMock.CalledTimesCounter)
-		assert.Greater(t, durationOfCall, time.Second * time.Duration(tc.minDuration))
 	}
 }


### PR DESCRIPTION
Closes #15 

Right now in `waitForQuery` we recheck if the query is done every second, this PR instead does a progressive backoff with the Fibonacci sequence so it'll be checks the first time right away, then waits a second and rechecks, then waits another second and rechecks, then waits 2 seconds, 3, 5, 8, and so on. 