### PR TITLE
Add Fill value parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ order by
   start_time,query_type ASC;
 ```
 
+##### Fill mode
+
+Grafana also supports to autocomplete frames without a value with some default. To configure this value, change the "Fill Value" in the query editor.
+
 #### Inspecting the query
 
 Because Grafana supports macros that Redshift does not, the fully rendered query, which can be copy/pasted directly into Redshift, is visible in the Query Inspector. To view the full interpolated query, click the Query Inspector button, and the full query will be visible under the "Query" tab.

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/google/go-cmp v0.5.5
 	github.com/grafana/grafana-aws-sdk v0.6.0
 	github.com/grafana/grafana-plugin-sdk-go v0.104.0
-	github.com/grafana/sqlds v1.2.0
-	github.com/jpillora/backoff v1.0.0 // indirect
+	github.com/grafana/sqlds v1.3.0
+	github.com/jpillora/backoff v1.0.0
 	github.com/mattn/go-runewidth v0.0.10 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -133,8 +133,8 @@ github.com/grafana/grafana-plugin-sdk-go v0.79.0/go.mod h1:NvxLzGkVhnoBKwzkst6CF
 github.com/grafana/grafana-plugin-sdk-go v0.94.0/go.mod h1:3VXz4nCv6wH5SfgB3mlW39s+c+LetqSCjFj7xxPC5+M=
 github.com/grafana/grafana-plugin-sdk-go v0.104.0 h1:Ij2tPdEasSjCb2MxHaaiylyW4RLVZYyWpApzN/mlTxo=
 github.com/grafana/grafana-plugin-sdk-go v0.104.0/go.mod h1:D7x3ah+1d4phNXpbnOaxa/osSaZlwh9/ZUnGGzegRbk=
-github.com/grafana/sqlds v1.2.0 h1:9N+e5rrg10qVqu44SB1j6nZAEGobN9PW4tBTlU7wb0s=
-github.com/grafana/sqlds v1.2.0/go.mod h1:YAUp48fa9P65GPkbyjlPWAAkcipS4ksx/QsVqw5Gs/k=
+github.com/grafana/sqlds v1.3.0 h1:xAFsJKXTgGTBactch1qsO37IF8GkHTT7EI41uQ+bieY=
+github.com/grafana/sqlds v1.3.0/go.mod h1:YAUp48fa9P65GPkbyjlPWAAkcipS4ksx/QsVqw5Gs/k=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.0/go.mod h1:mJzapYve32yjrKlk9GbyCZHuPgZsrbyIbyKhSzOpg6s=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=

--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
     "@testing-library/user-event": "^13.1.9",
     "@types/lodash": "latest",
     "cypress": "7.7.0",
-    "tslib": "^2.3.0",
-    "semver": "^7.1.3"
+    "react-select-event": "^5.3.0",
+    "semver": "^7.1.3",
+    "tslib": "^2.3.0"
   },
   "resolutions": {
     "rxjs": "6.6.3"

--- a/pkg/redshift/macros.go
+++ b/pkg/redshift/macros.go
@@ -42,17 +42,13 @@ func macroTimeTo(query *sqlds.Query, args []string) (string, error) {
 }
 
 func macroTimeGroup(query *sqlds.Query, args []string) (string, error) {
-	if len(args) < 2 {
-		return "", errors.WithMessagef(sqlds.ErrorBadArgumentCount, "macro $__timeGroup needs time column and interval and optional fill value")
+	if len(args) != 2 {
+		return "", errors.WithMessagef(sqlds.ErrorBadArgumentCount, "macro $__timeGroup needs time column and interval")
 	}
 
 	interval, err := gtime.ParseInterval(strings.Trim(args[1], `'`))
 	if err != nil {
 		return "", fmt.Errorf("error parsing interval %v", args[1])
-	}
-
-	if len(args) == 3 {
-		return "", fmt.Errorf("fill mode is not yet implemented")
 	}
 
 	return fmt.Sprintf("floor(extract(epoch from %s)/%v)*%v AS \"time\"", args[0], interval.Seconds(), interval.Seconds()), nil
@@ -85,17 +81,13 @@ func macroUnixEpochFilter(query *sqlds.Query, args []string) (string, error) {
 }
 
 func macroUnixEpochGroup(query *sqlds.Query, args []string) (string, error) {
-	if len(args) < 2 {
-		return "", errors.WithMessagef(sqlds.ErrorBadArgumentCount, "macro $__unixEpochGroup needs time column and interval and optional fill value")
+	if len(args) != 2 {
+		return "", errors.WithMessagef(sqlds.ErrorBadArgumentCount, "macro $__unixEpochGroup needs time column and interval")
 	}
 
 	interval, err := gtime.ParseInterval(strings.Trim(args[1], `'`))
 	if err != nil {
 		return "", fmt.Errorf("error parsing interval %v", args[1])
-	}
-
-	if len(args) == 3 {
-		return "", fmt.Errorf("fill mode is not yet implemented")
 	}
 
 	return fmt.Sprintf(`floor(%s/%v)*%v AS "time"`, args[0], interval.Seconds(), interval.Seconds()), nil

--- a/src/QueryEditor.test.tsx
+++ b/src/QueryEditor.test.tsx
@@ -3,6 +3,8 @@ import { render, screen } from '@testing-library/react';
 import { QueryEditor } from './QueryEditor';
 import { mockDatasource, mockQuery } from './__mocks__/datasource';
 import '@testing-library/jest-dom';
+import { select } from 'react-select-event';
+import { FillValueOptions } from 'types';
 
 const ds = mockDatasource;
 const q = mockQuery;
@@ -32,5 +34,19 @@ describe('QueryEditor', () => {
   it('should include the Format As input', async () => {
     render(<QueryEditor {...props} queries={[]} />);
     expect(screen.queryByText('Format as')).toBeInTheDocument();
+  });
+
+  it('should allow to change the fill mode', async () => {
+    const onChange = jest.fn();
+    render(<QueryEditor {...props} queries={[]} onChange={onChange} />);
+    const selectEl = screen.getByLabelText('Fill value');
+    expect(selectEl).toBeInTheDocument();
+
+    await select(selectEl, 'NULL', { container: document.body });
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...q,
+      fillMode: { mode: FillValueOptions.Null, value: 0 },
+    });
   });
 });

--- a/src/__mocks__/datasource.ts
+++ b/src/__mocks__/datasource.ts
@@ -32,6 +32,6 @@ export const mockDatasource = new DataSource({
   },
 });
 
-export const mockQuery: RedshiftQuery = { rawSQL: 'select * from foo', refId: '', format: 0 };
+export const mockQuery: RedshiftQuery = { rawSQL: 'select * from foo', refId: '', format: 0, fillMode: { mode: 0 } };
 
 export const mockSchemaInfo: SchemaInfo = new SchemaInfo(mockDatasource, mockQuery);

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,12 @@ export enum FormatOptions {
   Table,
 }
 
+export enum FillValueOptions {
+  Previous,
+  Null,
+  Value,
+}
+
 export const SelectableFormatOptions: Array<SelectableValue<FormatOptions>> = [
   {
     label: 'Time Series',
@@ -17,9 +23,25 @@ export const SelectableFormatOptions: Array<SelectableValue<FormatOptions>> = [
   },
 ];
 
+export const SelectableFillValueOptions: Array<SelectableValue<FillValueOptions>> = [
+  {
+    label: 'Previous Value',
+    value: FillValueOptions.Previous,
+  },
+  {
+    label: 'NULL',
+    value: FillValueOptions.Null,
+  },
+  {
+    label: 'Value',
+    value: FillValueOptions.Value,
+  },
+];
+
 export interface RedshiftQuery extends DataQuery {
   rawSQL: string;
   format: FormatOptions;
+  fillMode: { mode: FillValueOptions; value?: number };
 
   schema?: string;
   table?: string;
@@ -29,6 +51,7 @@ export interface RedshiftQuery extends DataQuery {
 export const defaultQuery: Partial<RedshiftQuery> = {
   rawSQL: '',
   format: FormatOptions.TimeSeries,
+  fillMode: { mode: FillValueOptions.Previous },
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1866,7 +1866,7 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@testing-library/dom@^8.0.0":
+"@testing-library/dom@>=7", "@testing-library/dom@^8.0.0":
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.1.0.tgz#f8358b1883844ea569ba76b7e94582168df5370d"
   integrity sha512-kmW9alndr19qd6DABzQ978zKQ+J65gU2Rzkl8hriIetPnwpesRaK4//jEQyYh8fEALmGhomD/LBQqt+o+DL95Q==
@@ -10930,6 +10930,13 @@ react-router@5.2.0:
     react-is "^16.6.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
+
+react-select-event@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/react-select-event/-/react-select-event-5.3.0.tgz#4548fffd615a47176951cbb301ee21a0c60b582a"
+  integrity sha512-Novkl7X9JJKmDV5LyYaKwl0vffWtqPrBa1vuI0v43P/f87mSA7JfdYxU93SFb99RssphVzBSIAbcnbX1w21QIQ==
+  dependencies:
+    "@testing-library/dom" ">=7"
 
 react-select@4.3.0:
   version "4.3.0"


### PR DESCRIPTION
Closes #63

For PostgreSQL, it's possible to define, for the macro `$__timeGroup` a default value, in case that the resulting frame doesn't have one. That has two disadvantages: that macro is more difficult to use and if several macros set that value it should return an error.

We thought (cc/ @kminehart) that a better UX would be to explicitly set that value as a parameter:

![Screenshot from 2021-07-27 13-10-59](https://user-images.githubusercontent.com/4025665/127145050-7f5f6b7d-bd4b-4b24-af22-1b22895c6158.png)

Note: This requires the changes on https://github.com/grafana/sqlds/pull/27 to work.

Additional note: I couldn't make the test work with `testing-library/react`, since the `grafana/ui` `Select` component is not rendered as a HTML `<select>` I could not make the test work. I found that the `enzyme` library is much easier to work with and more predictable on its result. Thoughts? We can also get rid of the weird console.errors that we are seeing in this repo if we switch to `enzyme`.
