### PR TITLE
Modify minimal policy in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ See the AWS documentation on [IAM Roles](http://docs.aws.amazon.com/AWSEC2/lates
 
 ### IAM policies
 
-Grafana needs permissions granted via IAM to be able to read Redshift metrics. You can attach these permissions to IAM roles and utilize Grafana's built-in support for assuming roles. Note that you will need to [configure the required policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_create.html) before adding the data source to Grafana. You can check some predefined policies by AWS [here](https://docs.aws.amazon.com/redshift/latest/mgmt/redshift-iam-access-control-identity-based.html#redshift-policy-resources.managed-policies).
+Grafana needs permissions granted via IAM to be able to read Redshift metrics. You can attach these permissions to IAM roles and utilize Grafana's built-in support for assuming roles. Note that you will need to [configure the required policy](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_create.html) before adding the data source to Grafana. [You can check some predefined policies by AWS here](https://docs.aws.amazon.com/redshift/latest/mgmt/redshift-iam-access-control-identity-based.html#redshift-policy-resources.managed-policies).
 
 Here is a minimal policy example:
 


### PR DESCRIPTION
Fixes #59

In the README we were specifying the predefined policy `AmazonRedshiftReadOnlyAccess` as the minimal policy example to access Redshift but in our use case, it is necessary some permissions to access the `redshift-data` (and many of the other actions are not needed).