### PR TITLE
Use AWS sdk packages for models and datasource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.38.62
 	github.com/google/go-cmp v0.5.6
 	// TODO: Replace with final version when ready
-	github.com/grafana/grafana-aws-sdk v0.7.1-0.20211213152905-b5c6292f2a5a
+	github.com/grafana/grafana-aws-sdk v0.7.1-0.20211215150526-39abfdfc63c2
 	github.com/grafana/grafana-plugin-sdk-go v0.114.0
 	github.com/grafana/sqlds/v2 v2.3.3
 	github.com/mattn/go-runewidth v0.0.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/grafana/grafana-aws-sdk v0.7.1-0.20211213152905-b5c6292f2a5a h1:+bTtwSEAPRytneD6R+OFcp+RGEqveqXm5ZZ+rPRRGtA=
-github.com/grafana/grafana-aws-sdk v0.7.1-0.20211213152905-b5c6292f2a5a/go.mod h1:NFffX96sJCXNrZsA3ag7Y9nHOFOMMQqmCnGmuSgwb0E=
+github.com/grafana/grafana-aws-sdk v0.7.1-0.20211215150526-39abfdfc63c2 h1:ZKcOBE+43tSPNch/L+vblMI4jFmBLfaT6OPSSPj8Ubw=
+github.com/grafana/grafana-aws-sdk v0.7.1-0.20211215150526-39abfdfc63c2/go.mod h1:NFffX96sJCXNrZsA3ag7Y9nHOFOMMQqmCnGmuSgwb0E=
 github.com/grafana/grafana-plugin-sdk-go v0.94.0/go.mod h1:3VXz4nCv6wH5SfgB3mlW39s+c+LetqSCjFj7xxPC5+M=
 github.com/grafana/grafana-plugin-sdk-go v0.114.0 h1:9I55IXw7mOT71tZ/pdqCaWGz8vxfz31CXjaDtBV9ZBo=
 github.com/grafana/grafana-plugin-sdk-go v0.114.0/go.mod h1:D7x3ah+1d4phNXpbnOaxa/osSaZlwh9/ZUnGGzegRbk=

--- a/pkg/redshift/api/api.go
+++ b/pkg/redshift/api/api.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/secretsmanager/secretsmanageriface"
 	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
 	"github.com/grafana/grafana-aws-sdk/pkg/sql/api"
+	awsModels "github.com/grafana/grafana-aws-sdk/pkg/sql/models"
 	"github.com/grafana/redshift-datasource/pkg/redshift/models"
 	"github.com/grafana/sqlds/v2"
 )
@@ -24,8 +25,9 @@ type API struct {
 	settings      *models.RedshiftDataSourceSettings
 }
 
-func New(sessionCache *awsds.SessionCache, settings *models.RedshiftDataSourceSettings) (api.AWSAPI, error) {
-	sess, err := awsds.GetSessionWithDefaultRegion(sessionCache, settings.AWSDatasourceSettings)
+func New(sessionCache *awsds.SessionCache, settings awsModels.Settings) (api.AWSAPI, error) {
+	redshiftSettings := settings.(*models.RedshiftDataSourceSettings)
+	sess, err := awsds.GetSessionWithDefaultRegion(sessionCache, redshiftSettings.AWSDatasourceSettings)
 	if err != nil {
 		return nil, err
 	}
@@ -41,7 +43,7 @@ func New(sessionCache *awsds.SessionCache, settings *models.RedshiftDataSourceSe
 	return &API{
 		Client:        svc,
 		SecretsClient: secretsSVC,
-		settings:      settings,
+		settings:      redshiftSettings,
 	}, nil
 }
 

--- a/pkg/redshift/datasource.go
+++ b/pkg/redshift/datasource.go
@@ -4,19 +4,16 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
-	"fmt"
 
-	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
 	sqlAPI "github.com/grafana/grafana-aws-sdk/pkg/sql/api"
+	"github.com/grafana/grafana-aws-sdk/pkg/sql/datasource"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
-	"github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
 	"github.com/grafana/redshift-datasource/pkg/redshift/api"
 	"github.com/grafana/redshift-datasource/pkg/redshift/driver"
 	"github.com/grafana/redshift-datasource/pkg/redshift/models"
 	"github.com/grafana/sqlds/v2"
-	"github.com/pkg/errors"
 )
 
 type RedshiftDatasourceIface interface {
@@ -31,13 +28,11 @@ type RedshiftDatasourceIface interface {
 }
 
 type RedshiftDatasource struct {
-	sessionCache *awsds.SessionCache
+	awsDS *datasource.AWSDatasource
 }
 
 func New() *RedshiftDatasource {
-	return &RedshiftDatasource{
-		sessionCache: awsds.NewSessionCache(),
-	}
+	return &RedshiftDatasource{awsDS: datasource.New()}
 }
 
 func (s *RedshiftDatasource) Settings(_ backend.DataSourceInstanceSettings) sqlds.DriverSettings {
@@ -53,51 +48,24 @@ func (s *RedshiftDatasource) Converters() (sc []sqlutil.Converter) {
 }
 
 // Connect opens a sql.DB connection using datasource settings
-func (s *RedshiftDatasource) Connect(config backend.DataSourceInstanceSettings, _ json.RawMessage) (*sql.DB, error) {
-	settings := models.RedshiftDataSourceSettings{}
-	err := settings.Load(config)
-	if err != nil {
-		return nil, fmt.Errorf("error reading settings: %s", err.Error())
-	}
-
-	api, err := api.New(s.sessionCache, &settings)
+func (s *RedshiftDatasource) Connect(config backend.DataSourceInstanceSettings, queryArgs json.RawMessage) (*sql.DB, error) {
+	s.awsDS.Init(config)
+	args, err := sqlds.ParseOptions(queryArgs)
 	if err != nil {
 		return nil, err
 	}
 
-	dr, err := driver.New(api)
-	if err != nil {
-		return nil, err
-	}
-	db, err := dr.OpenDB()
-	if err != nil {
-		return nil, errors.WithMessage(err, "Failed to connect to database. Is the hostname and port correct?")
-	}
-
-	return db, nil
+	return s.awsDS.GetDB(config.ID, args, models.New, api.New, driver.New)
 }
 
-func (s *RedshiftDatasource) getApi(ctx context.Context) (*api.API, error) {
-	plugin := httpadapter.PluginConfigFromContext(ctx)
-	if plugin.DataSourceInstanceSettings == nil {
-		return nil, fmt.Errorf("unable to get settings from request")
-	}
-
-	settings := models.RedshiftDataSourceSettings{}
-	err := settings.Load(*plugin.DataSourceInstanceSettings)
-	if err != nil {
-		return nil, fmt.Errorf("error reading settings: %s", err.Error())
-	}
-
-	res, err := api.New(s.sessionCache, &settings)
-	if err != nil {
-		return nil, err
-	}
-	return res.(*api.API), nil
+func (s *RedshiftDatasource) getApi(ctx context.Context, options sqlds.Options) (*api.API, error) {
+	id := datasource.GetDatasourceID(ctx)
+	res, err := s.awsDS.GetAPI(id, options, models.New, api.New)
+	return res.(*api.API), err
 }
 
 func (s *RedshiftDatasource) Regions(ctx context.Context) ([]string, error) {
-	api, err := s.getApi(ctx)
+	api, err := s.getApi(ctx, sqlds.Options{})
 	if err != nil {
 		return nil, err
 	}
@@ -109,7 +77,7 @@ func (s *RedshiftDatasource) Regions(ctx context.Context) ([]string, error) {
 }
 
 func (s *RedshiftDatasource) Databases(ctx context.Context, options sqlds.Options) ([]string, error) {
-	api, err := s.getApi(ctx)
+	api, err := s.getApi(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +89,7 @@ func (s *RedshiftDatasource) Databases(ctx context.Context, options sqlds.Option
 }
 
 func (s *RedshiftDatasource) Schemas(ctx context.Context, options sqlds.Options) ([]string, error) {
-	api, err := s.getApi(ctx)
+	api, err := s.getApi(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +101,7 @@ func (s *RedshiftDatasource) Schemas(ctx context.Context, options sqlds.Options)
 }
 
 func (s *RedshiftDatasource) Tables(ctx context.Context, options sqlds.Options) ([]string, error) {
-	api, err := s.getApi(ctx)
+	api, err := s.getApi(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +113,7 @@ func (s *RedshiftDatasource) Tables(ctx context.Context, options sqlds.Options) 
 }
 
 func (s *RedshiftDatasource) Columns(ctx context.Context, options sqlds.Options) ([]string, error) {
-	api, err := s.getApi(ctx)
+	api, err := s.getApi(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +125,7 @@ func (s *RedshiftDatasource) Columns(ctx context.Context, options sqlds.Options)
 }
 
 func (s *RedshiftDatasource) Secrets(ctx context.Context, options sqlds.Options) ([]models.ManagedSecret, error) {
-	api, err := s.getApi(ctx)
+	api, err := s.getApi(ctx, options)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +133,7 @@ func (s *RedshiftDatasource) Secrets(ctx context.Context, options sqlds.Options)
 }
 
 func (s *RedshiftDatasource) Secret(ctx context.Context, options sqlds.Options) (*models.RedshiftSecret, error) {
-	api, err := s.getApi(ctx)
+	api, err := s.getApi(ctx, options)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/redshift/models/settings.go
+++ b/pkg/redshift/models/settings.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 
 	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
+	"github.com/grafana/grafana-aws-sdk/pkg/sql/models"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/sqlds/v2"
 )
 
 type ManagedSecret struct {
@@ -27,6 +29,10 @@ type RedshiftDataSourceSettings struct {
 	ManagedSecret     ManagedSecret
 }
 
+func New() models.Settings {
+	return &RedshiftDataSourceSettings{}
+}
+
 func (s *RedshiftDataSourceSettings) Load(config backend.DataSourceInstanceSettings) error {
 	if config.JSONData != nil && len(config.JSONData) > 1 {
 		if err := json.Unmarshal(config.JSONData, s); err != nil {
@@ -38,4 +44,19 @@ func (s *RedshiftDataSourceSettings) Load(config backend.DataSourceInstanceSetti
 	s.SecretKey = config.DecryptedSecureJSONData["secretKey"]
 
 	return nil
+}
+
+func (s *RedshiftDataSourceSettings) Apply(args sqlds.Options) {
+	region, database := args["region"], args["database"]
+	if region != "" {
+		if region == models.DefaultKey {
+			s.Region = s.DefaultRegion
+		} else {
+			s.Region = region
+		}
+	}
+
+	if database != "" && database != models.DefaultKey {
+		s.Database = database
+	}
 }


### PR DESCRIPTION
Ref: grafana/grafana-aws-sdk#28

Add the last two packaged added in the SDK `models` (which defines an interface to load settings) and `datasource` (that handles the logic to handle several connections). 

The good thing about this is that we get "for free" connection handling, being able to add a database selector in the query editor in the near future for Redshift (as we do for Athena).