### PR TITLE
Update aws-sdk version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/aws/aws-sdk-go v1.38.62
 	github.com/google/go-cmp v0.5.6
-	github.com/grafana/grafana-aws-sdk v0.8.0
+	github.com/grafana/grafana-aws-sdk v0.9.0
 	github.com/grafana/grafana-plugin-sdk-go v0.114.0
 	github.com/grafana/sqlds/v2 v2.3.3
 	github.com/mattn/go-runewidth v0.0.10 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/aws/aws-sdk-go v1.38.62
 	github.com/google/go-cmp v0.5.6
-	github.com/grafana/grafana-aws-sdk v0.9.0
+	github.com/grafana/grafana-aws-sdk v0.9.1
 	github.com/grafana/grafana-plugin-sdk-go v0.114.0
 	github.com/grafana/sqlds/v2 v2.3.3
 	github.com/mattn/go-runewidth v0.0.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/grafana/grafana-aws-sdk v0.9.0 h1:oAEpSlNaD09S25F2TX8WwxCwnKk/ModUh0Uxgl+NP6M=
-github.com/grafana/grafana-aws-sdk v0.9.0/go.mod h1:6KaQ8uUD4KpXr/b7bAC7zbfSXTVOiTk4XhIrwkGWn4w=
+github.com/grafana/grafana-aws-sdk v0.9.1 h1:jMZlsLsWnqOwLt2UNcLUsJ2z6289hLYlscK35QgS158=
+github.com/grafana/grafana-aws-sdk v0.9.1/go.mod h1:6KaQ8uUD4KpXr/b7bAC7zbfSXTVOiTk4XhIrwkGWn4w=
 github.com/grafana/grafana-plugin-sdk-go v0.94.0/go.mod h1:3VXz4nCv6wH5SfgB3mlW39s+c+LetqSCjFj7xxPC5+M=
 github.com/grafana/grafana-plugin-sdk-go v0.114.0 h1:9I55IXw7mOT71tZ/pdqCaWGz8vxfz31CXjaDtBV9ZBo=
 github.com/grafana/grafana-plugin-sdk-go v0.114.0/go.mod h1:D7x3ah+1d4phNXpbnOaxa/osSaZlwh9/ZUnGGzegRbk=

--- a/go.sum
+++ b/go.sum
@@ -126,8 +126,8 @@ github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/grafana/grafana-aws-sdk v0.8.0 h1:Q0t6szK5sSTzoY8MgYF0+FHt6BTb8+8pYto3GPxREo8=
-github.com/grafana/grafana-aws-sdk v0.8.0/go.mod h1:NFffX96sJCXNrZsA3ag7Y9nHOFOMMQqmCnGmuSgwb0E=
+github.com/grafana/grafana-aws-sdk v0.9.0 h1:oAEpSlNaD09S25F2TX8WwxCwnKk/ModUh0Uxgl+NP6M=
+github.com/grafana/grafana-aws-sdk v0.9.0/go.mod h1:6KaQ8uUD4KpXr/b7bAC7zbfSXTVOiTk4XhIrwkGWn4w=
 github.com/grafana/grafana-plugin-sdk-go v0.94.0/go.mod h1:3VXz4nCv6wH5SfgB3mlW39s+c+LetqSCjFj7xxPC5+M=
 github.com/grafana/grafana-plugin-sdk-go v0.114.0 h1:9I55IXw7mOT71tZ/pdqCaWGz8vxfz31CXjaDtBV9ZBo=
 github.com/grafana/grafana-plugin-sdk-go v0.114.0/go.mod h1:D7x3ah+1d4phNXpbnOaxa/osSaZlwh9/ZUnGGzegRbk=

--- a/pkg/redshift/api/api.go
+++ b/pkg/redshift/api/api.go
@@ -26,11 +26,14 @@ type API struct {
 
 func New(sessionCache *awsds.SessionCache, settings awsModels.Settings) (api.AWSAPI, error) {
 	redshiftSettings := settings.(*models.RedshiftDataSourceSettings)
-	sess, err := awsds.GetSessionWithDefaultRegion(sessionCache, redshiftSettings.AWSDatasourceSettings)
+	sess, err := sessionCache.GetSession(awsds.SessionConfig{
+		Settings:      redshiftSettings.AWSDatasourceSettings,
+		Config:        redshiftSettings.Config,
+		UserAgentName: aws.String("Redshift"),
+	})
 	if err != nil {
 		return nil, err
 	}
-	awsds.WithUserAgent(sess, "Redshift")
 
 	return &API{
 		Client:        redshiftdataapiservice.New(sess),

--- a/pkg/redshift/models/settings.go
+++ b/pkg/redshift/models/settings.go
@@ -22,6 +22,7 @@ type RedshiftSecret struct {
 
 type RedshiftDataSourceSettings struct {
 	awsds.AWSDatasourceSettings
+	Config            backend.DataSourceInstanceSettings
 	ClusterIdentifier string `json:"clusterIdentifier"`
 	Database          string `json:"database"`
 	UseManagedSecret  bool   `json:"useManagedSecret"`
@@ -42,6 +43,8 @@ func (s *RedshiftDataSourceSettings) Load(config backend.DataSourceInstanceSetti
 
 	s.AccessKey = config.DecryptedSecureJSONData["accessKey"]
 	s.SecretKey = config.DecryptedSecureJSONData["secretKey"]
+
+	s.Config = config
 
 	return nil
 }


### PR DESCRIPTION
Ref [#39089](https://github.com/grafana/grafana/issues/39089)

Update `grafana-aws-sdk` to use the backend HTTP client provider.

