### PR TITLE
Return rows with null values. Only show fill value input for time series

### DIFF
--- a/pkg/redshift/driver/rows.go
+++ b/pkg/redshift/driver/rows.go
@@ -201,6 +201,7 @@ func (r *Rows) fetchNextPage(token *string) error {
 func convertRow(columns []*redshiftdataapiservice.ColumnMetadata, data []*redshiftdataapiservice.Field, ret []driver.Value) error {
 	for i, curr := range data {
 		if curr.IsNull != nil && *curr.IsNull {
+			ret[i] = nil
 			continue
 		}
 

--- a/pkg/redshift/driver/rows_test.go
+++ b/pkg/redshift/driver/rows_test.go
@@ -383,6 +383,19 @@ func Test_convertRow(t *testing.T) {
 			expectedValue: `2021-07-15 14:00:00 +0000 UTC`,
 			Err:           require.NoError,
 		},
+		{
+			name: "null",
+			metadata: &redshiftdataapiservice.ColumnMetadata{
+				Name:     aws.String("id"),
+				TypeName: aws.String(REDSHIFT_INT8),
+			},
+			data: &redshiftdataapiservice.Field{
+				IsNull: aws.Bool(true),
+			},
+			expectedType:  "<nil>",
+			expectedValue: "<nil>",
+			Err:           require.NoError,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/redshift/driver/rows_test.go
+++ b/pkg/redshift/driver/rows_test.go
@@ -384,11 +384,8 @@ func Test_convertRow(t *testing.T) {
 			Err:           require.NoError,
 		},
 		{
-			name: "null",
-			metadata: &redshiftdataapiservice.ColumnMetadata{
-				Name:     aws.String("id"),
-				TypeName: aws.String(REDSHIFT_INT8),
-			},
+			name:     "null",
+			metadata: &redshiftdataapiservice.ColumnMetadata{},
 			data: &redshiftdataapiservice.Field{
 				IsNull: aws.Bool(true),
 			},
@@ -411,4 +408,24 @@ func Test_convertRow(t *testing.T) {
 			assert.Equal(t, tt.expectedValue, fmt.Sprintf("%v", res[0]))
 		})
 	}
+
+	t.Run("a value followed by a null value", func(t *testing.T) {
+		// simulate previous value
+		res := []driver.Value{int32(1), int32(2)}
+
+		metadata := []*redshiftdataapiservice.ColumnMetadata{
+			{Name: aws.String("num"), TypeName: aws.String(REDSHIFT_INT)},
+			{},
+		}
+		data := []*redshiftdataapiservice.Field{
+			{LongValue: aws.Int64(3)},
+			{IsNull: aws.Bool(true)},
+		}
+
+		err := convertRow(metadata, data, res)
+		require.NoError(t, err)
+
+		expectedValue := []driver.Value{int32(3), nil}
+		assert.Equal(t, expectedValue, res)
+	})
 }

--- a/src/QueryEditor.test.tsx
+++ b/src/QueryEditor.test.tsx
@@ -1,11 +1,13 @@
-import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
-import { QueryEditor } from './QueryEditor';
-import { mockDatasource, mockQuery } from './__mocks__/datasource';
 import '@testing-library/jest-dom';
-import { select } from 'react-select-event';
-import { FillValueOptions } from 'types';
+
 import * as runtime from '@grafana/runtime';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { select } from 'react-select-event';
+import { FillValueOptions, FormatOptions } from 'types';
+
+import { mockDatasource, mockQuery } from './__mocks__/datasource';
+import { QueryEditor } from './QueryEditor';
 
 jest
   .spyOn(runtime, 'getTemplateSrv')
@@ -95,6 +97,21 @@ describe('QueryEditor', () => {
   it('should include the Format As input', async () => {
     render(<QueryEditor {...props} />);
     await waitFor(() => screen.getByText('Format as'));
+  });
+
+  it('should skip the fill mode input if the format is not TimeSeries', async () => {
+    const onChange = jest.fn();
+    render(
+      <QueryEditor
+        {...props}
+        query={{ ...props.query, format: FormatOptions.Table }}
+        queries={[]}
+        onChange={onChange}
+      />
+    );
+    await waitFor(() => screen.getByText('Format as'));
+    const selectEl = screen.queryByLabelText('Fill value');
+    expect(selectEl).not.toBeInTheDocument();
   });
 
   it('should allow to change the fill mode', async () => {

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import { FillValueSelect, FormatSelect, QueryCodeEditor, ResourceSelector } from '@grafana/aws-sdk';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
-import { DataSource } from './datasource';
-import { RedshiftDataSourceOptions, RedshiftQuery, SelectableFormatOptions } from './types';
 import { InlineSegmentGroup } from '@grafana/ui';
-import { QueryCodeEditor, FormatSelect, ResourceSelector, FillValueSelect } from '@grafana/aws-sdk';
+import React from 'react';
 import { selectors } from 'selectors';
 import { getSuggestions } from 'Suggestions';
+
+import { DataSource } from './datasource';
+import { FormatOptions, RedshiftDataSourceOptions, RedshiftQuery, SelectableFormatOptions } from './types';
 
 type Props = QueryEditorProps<DataSource, RedshiftQuery, RedshiftDataSourceOptions>;
 
@@ -86,7 +87,9 @@ export function QueryEditor(props: Props) {
             onChange={props.onChange}
             onRunQuery={props.onRunQuery}
           />
-          <FillValueSelect query={props.query} onChange={props.onChange} onRunQuery={props.onRunQuery} />{' '}
+          {props.query.format === FormatOptions.TimeSeries && (
+            <FillValueSelect query={props.query} onChange={props.onChange} onRunQuery={props.onRunQuery} />
+          )}
         </div>
         <div style={{ minWidth: '400px', marginLeft: '10px', flex: 1 }}>
           <QueryCodeEditor


### PR DESCRIPTION
Fixes #110 

This PR fixes the following:

> There are two different issues here:
> - The Fill Value input only applies when the frames are formatted as Time Series. This is used to fill frames in the Time Series panel. We should not show it for table frames since it's indeed confusing.
> - Null values should be returned as `null` not the previous value (this is the behavior of the PostgreSQL data source, for example).

![Screenshot from 2022-01-18 13-07-24](https://user-images.githubusercontent.com/4025665/149934659-4c5d0883-85d8-4c83-bb0d-e106f5a7cb96.png)

