### PR TITLE
Check nil column type when when converting redshift data api row

### DIFF
--- a/pkg/redshift/driver/rows.go
+++ b/pkg/redshift/driver/rows.go
@@ -205,6 +205,9 @@ func convertRow(columns []*redshiftdataapiservice.ColumnMetadata, data []*redshi
 		}
 
 		col := columns[i]
+		if col.TypeName == nil {
+			return fmt.Errorf("error in convertRow: col.TypeName is nil")
+		}
 		typeName := strings.ToUpper(*col.TypeName)
 		switch typeName {
 		case REDSHIFT_INT2:

--- a/pkg/redshift/driver/rows_test.go
+++ b/pkg/redshift/driver/rows_test.go
@@ -427,8 +427,9 @@ func Test_convertRow(t *testing.T) {
 
 		expectedValue := []driver.Value{int32(3), nil}
 		assert.Equal(t, expectedValue, res)
-    
-  t.Run("error returned for missing column type", func(t *testing.T) {
+	})
+
+	t.Run("error returned for missing column type", func(t *testing.T) {
 		assert.EqualError(t, convertRow(
 			[]*redshiftdataapiservice.ColumnMetadata{{}},
 			[]*redshiftdataapiservice.Field{{}},

--- a/pkg/redshift/driver/rows_test.go
+++ b/pkg/redshift/driver/rows_test.go
@@ -398,12 +398,12 @@ func Test_convertRow(t *testing.T) {
 			assert.Equal(t, tt.expectedValue, fmt.Sprintf("%v", res[0]))
 		})
 	}
-}
 
-func Test_convertRow_returns_error_for_missing_column_type(t *testing.T) {
-	assert.EqualError(t, convertRow(
-		[]*redshiftdataapiservice.ColumnMetadata{{}},
-		[]*redshiftdataapiservice.Field{{}},
-		[]driver.Value{},
-	), "error in convertRow: col.TypeName is nil")
+	t.Run("error returned for missing column type", func(t *testing.T) {
+		assert.EqualError(t, convertRow(
+			[]*redshiftdataapiservice.ColumnMetadata{{}},
+			[]*redshiftdataapiservice.Field{{}},
+			[]driver.Value{},
+		), "error in convertRow: col.TypeName is nil")
+	})
 }

--- a/pkg/redshift/driver/rows_test.go
+++ b/pkg/redshift/driver/rows_test.go
@@ -399,3 +399,11 @@ func Test_convertRow(t *testing.T) {
 		})
 	}
 }
+
+func Test_convertRow_returns_error_for_missing_column_type(t *testing.T) {
+	assert.EqualError(t, convertRow(
+		[]*redshiftdataapiservice.ColumnMetadata{{}},
+		[]*redshiftdataapiservice.Field{{}},
+		[]driver.Value{},
+	), "error in convertRow: col.TypeName is nil")
+}


### PR DESCRIPTION
Not sure the column TypeName will ever be empty, but this is just a defensive check added to the code. 