### PR TITLE
chore: add to GH Projects automatically

### DIFF
--- a/.github/issue_commands.json
+++ b/.github/issue_commands.json
@@ -1,0 +1,18 @@
+[   
+    {
+      "type": "label",
+      "name": "datasource/Redshift",
+      "action": "addToProject",
+      "addToProject": {
+        "url": "https://github.com/orgs/grafana/projects/97"
+      }
+    },
+    {
+      "type": "label",
+      "name": "type/docs",
+      "action": "addToProject",
+      "addToProject": {
+        "url": "https://github.com/orgs/grafana/projects/69"
+      }
+    }
+]

--- a/.github/workflows/issue_commands.yml
+++ b/.github/workflows/issue_commands.yml
@@ -1,0 +1,21 @@
+name: Run commands when issues are labeled
+on:
+  issues:
+    types: [labeled]
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: "grafana/grafana-github-actions"
+          path: ./actions
+          ref: main
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run Commands
+        uses: ./actions/commands
+        with:          
+          token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+          configPath: issue_commands

--- a/.github/workflows/issue_commands.yml
+++ b/.github/workflows/issue_commands.yml
@@ -2,6 +2,8 @@ name: Run commands when issues are labeled
 on:
   issues:
     types: [labeled]
+  pull_request:
+    types: [labeled]
 jobs:
   main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Currently, we automatically add the label `datasource/*` to new issues.
This PR uses the existing GH action already set up to additionally add them to our GH Projects board.

Ideally, this should be done without relying on the `datasource/*` label (since now we have two places where the label is defined: `issue_commands.json` and `1-bug_report.md`) but can use what we have in place for now and come up with another way of doing this later.

**TODO:**
Need to new secret to this repository called `GH_BOT_ACCESS_TOKEN` as it is required by this action to be able to work properly