### PR TITLE
Adding github actions that are triggered when issues and prs are labeled

### DIFF
--- a/.github/issue_and_pr_commands.json
+++ b/.github/issue_and_pr_commands.json
@@ -1,0 +1,18 @@
+[
+  {
+    "type": "label",
+    "name": "datasource/Redshift",
+    "action": "addToProject",
+    "addToProject": {
+      "url": "https://github.com/orgs/grafana/projects/97"
+    }
+  },
+    {
+      "type": "label",
+      "name": "type/docs",
+      "action": "addToProject",
+      "addToProject": {
+        "url": "https://github.com/orgs/grafana/projects/69"
+      }
+    }
+]

--- a/.github/workflows/issue_and_pr_commands.yml
+++ b/.github/workflows/issue_and_pr_commands.yml
@@ -1,0 +1,23 @@
+name: Run commands when issues or PRs are labeled
+on:
+  issues:
+    types: [labeled]
+  pull_request:
+    types: [labeled]
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: "grafana/grafana-github-actions"
+          path: ./actions
+          ref: main
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run Commands
+        uses: ./actions/commands
+        with:          
+          token: ${{secrets.GH_BOT_ACCESS_TOKEN}}
+          configPath: issue_and_pr_commands


### PR DESCRIPTION

Makes this one obsolete: https://github.com/grafana/redshift-datasource/pull/118

Adds github actions that trigger when issues or PRs are labled. The necessary token is added to the repository settings already.