### PR TITLE
Update release docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,19 +53,7 @@ You need to have commit rights to the GitHub repository to publish a release.
 1. Update the version number in the `package.json` file.
 2. Update the `CHANGELOG.md` with the changes contained in the release.
 3. Commit the changes to master and push to GitHub.
-4. Create a tag locally that follows the convention v(major).(minor).x, leaving the patch as `x`. For example:
-
-   ```bash
-   git tag v3.3.0
-   ```
-
-5. Push the new tag to GitHub
-
-   ```bash
-   git push origin main --tags
-   ```
-
-6. Follow the Drone release process that you can find [here](https://github.com/grafana/integrations-team/wiki/Plugin-Release-Process#drone-release-process)
+4. Follow the Drone release process that you can find [here](https://github.com/grafana/integrations-team/wiki/Plugin-Release-Process#drone-release-process)
 
 # Plugin Technical Documentation
 


### PR DESCRIPTION
Just noticed that there is no need to create a tag locally and push it. The release process will automatically do it.