### PR TITLE
Issue 61 : Frontend - Add details in the datasource card

### DIFF
--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -112,7 +112,7 @@ e2e.scenario({
             e2e().get('label').contains('AWS Secrets Manager').click({ force: true });
             e2eSelectors.ConfigEditor.ManagedSecret.input().click({ force: true });
             // wait for it to load
-            // e2eSelectors.ConfigEditor.ManagedSecret.testID().contains(datasource.jsonData.managedSecret.name);
+            e2eSelectors.ConfigEditor.ManagedSecret.testID().contains(datasource.jsonData.managedSecret.name);
             e2eSelectors.ConfigEditor.ManagedSecret.input()
               .type(datasource.jsonData.managedSecret.name)
               .type('{enter}');

--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -112,12 +112,15 @@ e2e.scenario({
             e2e().get('label').contains('AWS Secrets Manager').click({ force: true });
             e2eSelectors.ConfigEditor.ManagedSecret.input().click({ force: true });
             // wait for it to load
-            e2eSelectors.ConfigEditor.ManagedSecret.testID().contains(datasource.jsonData.managedSecret.name);
+            // e2eSelectors.ConfigEditor.ManagedSecret.testID().contains(datasource.jsonData.managedSecret.name);
             e2eSelectors.ConfigEditor.ManagedSecret.input()
               .type(datasource.jsonData.managedSecret.name)
               .type('{enter}');
             // wait for the secret to be retrieved
-            e2eSelectors.ConfigEditor.ClusterID.testID().should('have.value', datasource.jsonData.clusterIdentifier);
+            e2eSelectors.ConfigEditor.ClusterIDText.testID().should(
+              'have.value',
+              datasource.jsonData.clusterIdentifier
+            );
             e2eSelectors.ConfigEditor.Database.testID()
               .click({ force: true })
               .type(datasource.jsonData.database, { delay: 20 });

--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -111,11 +111,10 @@ e2e.scenario({
               .type('{enter}');
             e2e().get('label').contains('AWS Secrets Manager').click({ force: true });
             e2eSelectors.ConfigEditor.ManagedSecret.input().click({ force: true });
+            e2eSelectors.ConfigEditor.ManagedSecret.input().type(datasource.jsonData.managedSecret.name);
             // wait for it to load
             e2eSelectors.ConfigEditor.ManagedSecret.testID().contains(datasource.jsonData.managedSecret.name);
-            e2eSelectors.ConfigEditor.ManagedSecret.input()
-              .type(datasource.jsonData.managedSecret.name)
-              .type('{enter}');
+            e2eSelectors.ConfigEditor.ManagedSecret.input().type('{enter}');
             // wait for the secret to be retrieved
             e2eSelectors.ConfigEditor.ClusterIDText.testID().should(
               'have.value',

--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -55,10 +55,10 @@ e2e.scenario({
               .click({ force: true })
               .type(datasource.jsonData.defaultRegion)
               .type('{enter}');
-            e2eSelectors.ConfigEditor.ClusterID.testID()
-              .click({ force: true })
-              .type(datasource.jsonData.clusterIdentifier)
-              .type('{enter}');
+            // e2eSelectors.ConfigEditor.ClusterID.input().click({ force: true });
+            // // wait for it to load
+            // e2eSelectors.ConfigEditor.ClusterID.testID().contains(datasource.jsonData.clusterIdentifier);
+            // e2eSelectors.ConfigEditor.ClusterID.input().type(datasource.jsonData.clusterIdentifier).type('{enter}');
             e2eSelectors.ConfigEditor.Database.testID().click({ force: true }).type(datasource.jsonData.database);
             e2eSelectors.ConfigEditor.DatabaseUser.testID().click({ force: true }).type(datasource.jsonData.dbUser);
           },

--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -57,7 +57,8 @@ e2e.scenario({
               .type('{enter}');
             e2eSelectors.ConfigEditor.ClusterID.testID()
               .click({ force: true })
-              .type(datasource.jsonData.clusterIdentifier);
+              .type(datasource.jsonData.clusterIdentifier)
+              .type('{enter}');
             e2eSelectors.ConfigEditor.Database.testID().click({ force: true }).type(datasource.jsonData.database);
             e2eSelectors.ConfigEditor.DatabaseUser.testID().click({ force: true }).type(datasource.jsonData.dbUser);
           },

--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -55,10 +55,10 @@ e2e.scenario({
               .click({ force: true })
               .type(datasource.jsonData.defaultRegion)
               .type('{enter}');
-            // e2eSelectors.ConfigEditor.ClusterID.input().click({ force: true });
-            // // wait for it to load
-            // e2eSelectors.ConfigEditor.ClusterID.testID().contains(datasource.jsonData.clusterIdentifier);
-            // e2eSelectors.ConfigEditor.ClusterID.input().type(datasource.jsonData.clusterIdentifier).type('{enter}');
+            e2eSelectors.ConfigEditor.ClusterID.input().click({ force: true });
+            // wait for it to load
+            e2eSelectors.ConfigEditor.ClusterID.testID().contains(datasource.jsonData.clusterIdentifier);
+            e2eSelectors.ConfigEditor.ClusterID.input().type(datasource.jsonData.clusterIdentifier).type('{enter}');
             e2eSelectors.ConfigEditor.Database.testID().click({ force: true }).type(datasource.jsonData.database);
             e2eSelectors.ConfigEditor.DatabaseUser.testID().click({ force: true }).type(datasource.jsonData.dbUser);
           },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@grafana/aws-sdk": "0.0.33",
+    "@grafana/aws-sdk": "0.0.35",
     "@grafana/data": "8.0.5",
     "@grafana/e2e": "8.1.2",
     "@grafana/e2e-selectors": "8.1.2",

--- a/src/ConfigEditor/ConfigEditor.test.tsx
+++ b/src/ConfigEditor/ConfigEditor.test.tsx
@@ -37,17 +37,23 @@ const props = mockDatasourceOptions;
 describe('ConfigEditor', () => {
   it('should display temporary credentials by default', () => {
     render(<ConfigEditor {...props} />);
-    expect(screen.getByText(selectors.components.ConfigEditor.ClusterID.input)).toBeInTheDocument();
-    expect(screen.getByText(selectors.components.ConfigEditor.Database.input)).toBeInTheDocument();
-    expect(screen.getByText(selectors.components.ConfigEditor.DatabaseUser.input)).toBeInTheDocument();
+    expect(screen.getByText(selectors.components.ConfigEditor.ManagedSecret.input)).not.toBeVisible();
+    expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterIDText.testID)).not.toBeVisible();
+    expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterID.testID)).toBeVisible();
+    expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterID.testID)).not.toBeDisabled();
+    expect(screen.getByText(selectors.components.ConfigEditor.DatabaseUser.input)).not.toBeDisabled();
+    expect(screen.getByText(selectors.components.ConfigEditor.Database.input)).not.toBeDisabled();
   });
 
   it('should switch to use the Secret Manager', () => {
     render(<ConfigEditor {...props} />);
     screen.getByText('AWS Secrets Manager').click();
-    expect(screen.getByText(selectors.components.ConfigEditor.ManagedSecret.input)).toBeInTheDocument();
-    expect(screen.getByText(selectors.components.ConfigEditor.ClusterID.input)).toBeInTheDocument();
-    expect(screen.getByText(selectors.components.ConfigEditor.Database.input)).toBeInTheDocument();
+    expect(screen.getByText(selectors.components.ConfigEditor.ManagedSecret.input)).toBeVisible();
+    expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterIDText.testID)).toBeVisible();
+    expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterIDText.testID)).toBeDisabled();
+    expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterID.testID)).not.toBeVisible();
+    expect(screen.getByTestId(selectors.components.ConfigEditor.DatabaseUser.testID)).toBeDisabled();
+    expect(screen.getByText(selectors.components.ConfigEditor.Database.input)).not.toBeDisabled();
   });
 
   it('should select a secret', async () => {

--- a/src/ConfigEditor/ConfigEditor.test.tsx
+++ b/src/ConfigEditor/ConfigEditor.test.tsx
@@ -81,8 +81,10 @@ describe('ConfigEditor', () => {
     });
   });
 
-  it('should populate the `url` prop when clusterIdentifier is set', async () => {
+  it('should populate the `url` prop when clusterIdentifier is selected', async () => {
     const onChange = jest.fn();
+    const propsWithDB = props;
+    propsWithDB.options.jsonData.database = 'test-db';
     render(<ConfigEditor {...props} onOptionsChange={onChange} />);
 
     const selectEl = screen.getByLabelText(selectors.components.ConfigEditor.ClusterID.input);
@@ -92,7 +94,7 @@ describe('ConfigEditor', () => {
     await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
     expect(onChange).toHaveBeenCalledWith({
       ...props.options,
-      url: 'foo.a.b.c:123/db',
+      url: 'foo.a.b.c:123/test-db',
       jsonData: { ...props.options.jsonData, clusterIdentifier: 'foo' },
     });
   });

--- a/src/ConfigEditor/ConfigEditor.test.tsx
+++ b/src/ConfigEditor/ConfigEditor.test.tsx
@@ -1,13 +1,16 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
-import { ConfigEditor } from './ConfigEditor';
-import { selectors } from '../selectors';
-import { mockDatasourceOptions } from '../__mocks__/datasource';
 import { select } from 'react-select-event';
+
+import { mockDatasourceOptions } from '../__mocks__/datasource';
+import { selectors } from '../selectors';
+import { ConfigEditor } from './ConfigEditor';
 
 const secret = { name: 'foo', arn: 'arn:foo' };
 const clusterIdentifier = 'cluster';
 const dbUser = 'username';
+const secretFetched = { dbClusterIdentifier: clusterIdentifier, username: dbUser };
+const cluster = { endpoint: { address: 'foo.a.b.c', port: 123 }, database: 'db' };
 
 jest.mock('@grafana/aws-sdk', () => {
   return {
@@ -23,7 +26,7 @@ jest.mock('@grafana/runtime', () => {
     ...(jest.requireActual('@grafana/runtime') as any),
     getBackendSrv: () => ({
       put: jest.fn().mockResolvedValue({ datasource: {} }),
-      post: jest.fn().mockResolvedValue({ dbClusterIdentifier: clusterIdentifier, username: dbUser }),
+      post: jest.fn().mockImplementation((url, args) => (url.includes('secret') ? secretFetched : cluster)),
       get: jest.fn().mockResolvedValue([secret]),
     }),
   };
@@ -60,6 +63,41 @@ describe('ConfigEditor', () => {
     expect(onChange).toHaveBeenCalledWith({
       ...props.options,
       jsonData: { ...props.options.jsonData, managedSecret: secret },
+    });
+  });
+
+  it('should allow user to enter a database', async () => {
+    const onChange = jest.fn();
+    render(<ConfigEditor {...props} onOptionsChange={onChange} />);
+
+    const dbField = screen.getByTestId('data-testid database');
+    expect(dbField).toBeInTheDocument();
+    fireEvent.change(dbField, { target: { value: 'abcd' } });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith({
+      ...props.options,
+      jsonData: { ...props.options.jsonData, database: 'abcd' },
+    });
+  });
+
+  it('should populate the `url` prop when clusterIdentifier is set', async () => {
+    const onChange = jest.fn();
+    const propsWithJson = {
+      options: {
+        ...props.options,
+        jsonData: {
+          clusterIdentifier: 'testCluster',
+        },
+      },
+      onOptionsChange: onChange,
+    };
+    render(<ConfigEditor {...propsWithJson} />);
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+    expect(onChange).toHaveBeenCalledWith({
+      ...propsWithJson.options,
+      url: 'foo.a.b.c:123/db',
     });
   });
 

--- a/src/ConfigEditor/ConfigEditor.test.tsx
+++ b/src/ConfigEditor/ConfigEditor.test.tsx
@@ -10,7 +10,7 @@ const secret = { name: 'foo', arn: 'arn:foo' };
 const clusterIdentifier = 'cluster';
 const dbUser = 'username';
 const secretFetched = { dbClusterIdentifier: clusterIdentifier, username: dbUser };
-const cluster = { clusterIdentifier: 'foo', endpoint: { address: 'foo.a.b.c', port: 123 }, database: 'db' };
+const cluster = { clusterIdentifier: 'cluster', endpoint: { address: 'foo.a.b.c', port: 123 }, database: 'db' };
 
 jest.mock('@grafana/aws-sdk', () => {
   return {
@@ -95,7 +95,7 @@ describe('ConfigEditor', () => {
     expect(onChange).toHaveBeenCalledWith({
       ...props.options,
       url: 'foo.a.b.c:123/test-db',
-      jsonData: { ...props.options.jsonData, clusterIdentifier: 'foo' },
+      jsonData: { ...props.options.jsonData, clusterIdentifier: clusterIdentifier },
     });
   });
 
@@ -116,6 +116,7 @@ describe('ConfigEditor', () => {
     await waitFor(() =>
       expect(onChange).toHaveBeenCalledWith({
         ...props.options,
+        url: 'foo.a.b.c:123/test-db',
         jsonData: {
           ...props.options.jsonData,
           dbUser,

--- a/src/ConfigEditor/ConfigEditor.tsx
+++ b/src/ConfigEditor/ConfigEditor.tsx
@@ -67,7 +67,6 @@ export function ConfigEditor(props: Props) {
     const res: Secret = await getBackendSrv().post(resourcesURL + '/secret', { secretARN: arn });
     return res;
   };
-  
   useEffect(() => {
     if (arn) {
       fetchSecret(arn).then((s) => {

--- a/src/ConfigEditor/ConfigEditor.tsx
+++ b/src/ConfigEditor/ConfigEditor.tsx
@@ -67,12 +67,12 @@ export function ConfigEditor(props: Props) {
     const res: Secret = await getBackendSrv().post(resourcesURL + '/secret', { secretARN: arn });
     return res;
   };
-  const { onOptionsChange: propsOnOptionsChange } = props;
+  
   useEffect(() => {
     if (arn) {
       fetchSecret(arn).then((s) => {
         getClusterUrl(s.dbClusterIdentifier).then((url) => {
-          propsOnOptionsChange({
+          props.onOptionsChange({
             ...props.options,
             url,
             jsonData: {
@@ -98,7 +98,7 @@ export function ConfigEditor(props: Props) {
 
   const getClusterUrl = async (clusterID: string) => {
     const { jsonData } = props.options;
-    if (clusterID != jsonData.clusterIdentifier) {
+    if (clusterID !== jsonData.clusterIdentifier) {
       const clusters = await fetchClusters();
       return `${clusters.find((c) => c.value === clusterID)?.description || clusterID}/${jsonData.database || ''}`;
     }
@@ -135,7 +135,7 @@ export function ConfigEditor(props: Props) {
   };
   const onChange = (resource: InputResourceType) => (e: FormEvent<HTMLInputElement>) => {
     const value = e.currentTarget.value;
-    const url = resource == 'database' ? props.options.url.replace(/\/.*$/, `/${value}`) : props.options.url;
+    const url = resource === 'database' ? props.options.url.replace(/\/.*$/, `/${value}`) : props.options.url;
     props.onOptionsChange({
       ...props.options,
       url,

--- a/src/ConfigEditor/ConfigEditor.tsx
+++ b/src/ConfigEditor/ConfigEditor.tsx
@@ -25,7 +25,7 @@ type Cluster = {
   database: string;
 };
 
-type InputResourceType = 'clusterIdentifier' | 'dbUser' | 'database';
+type InputResourceType = 'dbUser' | 'database';
 
 export function ConfigEditor(props: Props) {
   const baseURL = `/api/datasources/${props.options.id}`;
@@ -122,8 +122,10 @@ export function ConfigEditor(props: Props) {
   };
   const onChange = (resource: InputResourceType) => (e: FormEvent<HTMLInputElement>) => {
     const value = e.currentTarget.value;
+    const url = resource == 'database' ? props.options.url.replace(/\/.*$/, `/${value}`) : props.options.url;
     props.onOptionsChange({
       ...props.options,
+      url,
       jsonData: {
         ...props.options.jsonData,
         [resource]: value,

--- a/src/ConfigEditor/ConfigEditor.tsx
+++ b/src/ConfigEditor/ConfigEditor.tsx
@@ -148,6 +148,7 @@ export function ConfigEditor(props: Props) {
       />
       <ConfigSelect
         {...props}
+        allowCustomValue={true}
         value={props.options.jsonData.clusterIdentifier ?? ''}
         onChange={onChangeClusterID}
         fetch={fetchClusters}

--- a/src/ConfigEditor/ConfigEditor.tsx
+++ b/src/ConfigEditor/ConfigEditor.tsx
@@ -67,14 +67,6 @@ export function ConfigEditor(props: Props) {
     const res: Secret = await getBackendSrv().post(resourcesURL + '/secret', { secretARN: arn });
     return res;
   };
-  const fetchClusters = async () => {
-    const res: Cluster[] = await getBackendSrv().get(resourcesURL + '/clusters');
-    return res.map((c) => ({
-      label: c.clusterIdentifier,
-      value: c.clusterIdentifier,
-      description: `${c.endpoint.address}:${c.endpoint.port}/${c.database}`,
-    }));
-  };
   const { onOptionsChange: propsOnOptionsChange } = props;
   useEffect(() => {
     if (arn) {
@@ -90,6 +82,15 @@ export function ConfigEditor(props: Props) {
       });
     }
   }, [arn]);
+
+  const fetchClusters = async () => {
+    const res: Cluster[] = await getBackendSrv().get(resourcesURL + '/clusters');
+    return res.map((c) => ({
+      label: c.clusterIdentifier,
+      value: c.clusterIdentifier,
+      description: `${c.endpoint.address}:${c.endpoint.port}`,
+    }));
+  };
 
   const onOptionsChange = (options: RedshiftDataSourceSettings) => {
     setSaved(false);
@@ -109,7 +110,7 @@ export function ConfigEditor(props: Props) {
   };
   const onChangeClusterID = (e: SelectableValue<string> | null) => {
     const value = e?.value ?? '';
-    const url = e?.description ?? '';
+    const url = e?.description + '/' + props.options.jsonData.database ?? '';
     props.onOptionsChange({
       ...props.options,
       url,
@@ -153,7 +154,7 @@ export function ConfigEditor(props: Props) {
         label={selectors.components.ConfigEditor.ClusterID.input}
         data-testid={selectors.components.ConfigEditor.ClusterID.testID}
         saveOptions={saveOptions}
-        hidden={useManagedSecret}
+        disabled={useManagedSecret}
       />
       <InlineInput
         {...props}

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -22,6 +22,10 @@ export const Components = {
       input: 'Cluster Identifier',
       testID: 'data-testid clusterID',
     },
+    ClusterIDText: {
+      input: 'Cluster Identifier text',
+      testID: 'data-testid clusterID text',
+    },
     Database: {
       input: 'Database',
       testID: 'data-testid database',

--- a/src/selectors.ts
+++ b/src/selectors.ts
@@ -23,7 +23,7 @@ export const Components = {
       testID: 'data-testid clusterID',
     },
     ClusterIDText: {
-      input: 'Cluster Identifier text',
+      input: 'Cluster Identifier',
       testID: 'data-testid clusterID text',
     },
     Database: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1098,10 +1098,10 @@
   resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.3.tgz#bc632c6c77971a5474acbe45847420503679fc75"
   integrity sha512-V0PJLk+oU1C33knurXp8BkT5N2ctDu9b21zpK16vkJAs5aOiH/OaOhQ/IP9ipxYhB+b9PFjr8RXagV/8XJ8xwg==
 
-"@grafana/aws-sdk@0.0.33":
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.33.tgz#ed07a9ff81c0e2667fa4de1b6cc37122302d09e7"
-  integrity sha512-rue4RtbshZbLe44C1fCknRDAEZGAcSGsrxF2Ix0+vOpeIKcFSkKQ3ANKtWz4+D6l4GehG4NPJ2CjgbxAoF7M+Q==
+"@grafana/aws-sdk@0.0.35":
+  version "0.0.35"
+  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.35.tgz#ef1a1294decdb859f04f170f33cf45277703bb87"
+  integrity sha512-EUi4hF0NQ7c9+XfUvRfrCkxPVkzRFv4VdSMlUOyyg7FynKq4Do9HF+4gR30Krt0ct6zmloPIx2AAIHL5898g7A==
 
 "@grafana/data@8.0.5":
   version "8.0.5"


### PR DESCRIPTION
Fixes #61 

## Description
When listing datasources, a card is composed of a Heading ('Amazon Redshift'), a Figure (the logo) and some `meta` info. Meta include the datasource `typeName`, `url` and `isDefault`.

This PR uses the endpoint created by #129 to use a dropdown instead of an input field and populate the `url` field.

It also upgrades `aws-sdk` to use `allowCustomValue` in case the user does not have permission to fetch the clusters

On the `managed Secret` tab, the dropdown is hidden and a plain text field is shown. The reason for that is that since the dropdown gets its options populated dynamically, when selecting a secret it would not show the clusterID associated with it (as it's a disabled dropdown with no valid options)


### Screenshots

No change to the `managed secret` UI
Dropdown instead of text input for `Temp credential` UI
Details added to card in datasources list view

| Before | After |
|--------|-------|
|  ![Screenshot 2022-02-22 at 10 27 20](https://user-images.githubusercontent.com/42030685/155103017-d9fc4a81-3ff1-4340-b9a9-a28bc29c5429.png)    | ![Screenshot 2022-02-22 at 10 27 45](https://user-images.githubusercontent.com/42030685/156167171-0b7d4462-7b88-4ca5-9a8c-8690baf8c4f1.png)   |
|  <img width="400" alt="Screenshot 2022-03-07 at 20 03 24" src="https://user-images.githubusercontent.com/42030685/157100681-eed5e9c7-c91c-4a1a-b44d-e29b1db81893.png"> | <img width="400" alt="Screenshot 2022-03-07 at 20 03 36" src="https://user-images.githubusercontent.com/42030685/157100683-b928f8cb-ae32-451c-bb5d-9cecd3742dc8.png"> |
| ![Screenshot 2022-03-17 at 12 47 28](https://user-images.githubusercontent.com/42030685/158802216-bc2f80bb-aad2-4cec-8acb-16afe74dd3e3.png)  | ![Screenshot 2022-03-17 at 12 45 41](https://user-images.githubusercontent.com/42030685/158802029-f16d5d8f-bffe-49bb-9699-d94d44a32670.png) |

| If the user does not have permission to fetch the clusters, she can create one | And the `AWS Secret Manager` view works as expected |
|--------|-------|
| ![Screenshot 2022-03-18 at 09 54 39](https://user-images.githubusercontent.com/42030685/158970961-bd2ceb99-9d47-492b-bf7e-044ac3a70dfd.png) | ![Screenshot 2022-03-18 at 09 54 53](https://user-images.githubusercontent.com/42030685/158971325-b97ade59-caa7-4a0c-830b-cf85874c531d.png) |


## Test coverage
Running: `yarn test:coverage:change`

```
-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
  ConfigEditor.tsx |   91.23 |    79.31 |   94.74 |      90 | 39-44,95-96 
-------------------|---------|----------|---------|---------|-------------------
```
