### PR TITLE
Stop code coverage update/create comment for forks

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -4,4 +4,4 @@ on:
     branches-ignore: [dependabot/**]
 jobs:
   workflow-call:
-    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.0
+    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.1

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -4,4 +4,4 @@ on:
     branches-ignore: [dependabot/**]
 jobs:
   workflow-call:
-    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@forks
+    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.1

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -4,4 +4,4 @@ on:
     branches-ignore: [dependabot/**]
 jobs:
   workflow-call:
-    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.1
+    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@forks


### PR DESCRIPTION
-Stop code coverage workflow's update/create comment step for forks
-Split steps for go and TypeScript in order to get more granular timing information
-Change to go 1.17.8