### PR TITLE
Test: try ignore-public-forks branch of code cov workflow

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -4,4 +4,4 @@ on:
     branches-ignore: [dependabot/**]
 jobs:
   workflow-call:
-    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.0
+    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@forks

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -4,4 +4,4 @@ on:
     branches-ignore: [dependabot/**]
 jobs:
   workflow-call:
-    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@forks
+    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@comment

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -4,4 +4,4 @@ on:
     branches-ignore: [dependabot/**]
 jobs:
   workflow-call:
-    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@comment
+    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.1


### PR DESCRIPTION
This PR should *not* trigger the create and update comment step of the code coverage workflow