### PR TITLE
Release v1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.0.6
+
+### What's Changed
+* Update grafana-aws-sdk by @andresmgot in https://github.com/grafana/redshift-datasource/pull/146
+* Autocomplete: Render SQL editor in case feature toggle is enabled by @sunker in https://github.com/grafana/redshift-datasource/pull/151
+* fix: WLM panels query fix by @vgkowski in https://github.com/grafana/redshift-datasource/pull/152
+* Custom redshift language by @sunker in https://github.com/grafana/redshift-datasource/pull/154
+* Align Monaco language with official language ref by @sunker in https://github.com/grafana/redshift-datasource/pull/156
+
+**Full Changelog**: https://github.com/grafana/redshift-datasource/compare/v1.0.5...v1.0.6
+
 ## 1.0.5
 
 - Reduces backoff time factor to retrieve results.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-redshift-datasource",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Use Amazon Redshift in Grafana",
   "scripts": {
     "build": "grafana-toolkit plugin:build",


### PR DESCRIPTION
Fixes #160

Error occurs when connecting to us-gov-west-1 region.
Error message: `"message":"error executing query: InvalidClientTokenId: The security token included in the request is invalid\n\tstatus code: 403`

Investigation:
Redshift v1.0.5 includes grafana-aws-sdk v0.10.2 which included the following change: https://github.com/grafana/grafana-aws-sdk/commit/fb334157a44592a9ef9ba6b3621f1191bf06a497

Redshift v1.0.2 uses grafana-aws-sdk v0.9.1 which was the last Redshift version without that change.
Downgrading to Redshift plugin version 1.0.2 resolves the above error.

Proposed solution:
Because Redshift v1.0.2 is connecting successfully for the original issue reporter, we think that releasing Redshift with a fixed grafana-aws-sdk will resolve the issue (as it did for the same problem in Athena). 