### PR TITLE
Add custom completion item provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@grafana/runtime": "8.0.5",
     "@grafana/toolkit": "8.0.5",
     "@grafana/ui": "8.0.5",
-    "@grafana/experimental": "^0.0.2-canary.33",
+    "@grafana/experimental": "^0.0.2-canary.37",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",
     "@testing-library/user-event": "^13.1.9",

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -95,7 +95,7 @@ export function QueryEditor(props: Props) {
         </div>
         <div style={{ minWidth: '400px', marginLeft: '10px', flex: 1 }}>
           {config.featureToggles.redshiftExperimentalUI ? (
-            <RedshiftSQLEditor query={props.query} onChange={props.onChange} />
+            <RedshiftSQLEditor query={props.query} onChange={props.onChange} datasource={props.datasource} />
           ) : (
             <QueryCodeEditor
               language="redshift"

--- a/src/RedshiftSQLEditor/index.tsx
+++ b/src/RedshiftSQLEditor/index.tsx
@@ -1,19 +1,55 @@
 import { SQLEditor } from '@grafana/experimental';
+import { DataSource } from 'datasource';
+import { getRedshiftCompletionProvider } from 'language/completionItemProvider';
 import redshiftLanguageDefinition from 'language/definition';
-import React from 'react';
+import React, { useRef, useMemo, useCallback } from 'react';
 import { RedshiftQuery } from 'types';
 
 interface RawEditorProps {
   query: RedshiftQuery;
   onChange: (q: RedshiftQuery) => void;
+  datasource: DataSource;
 }
 
-export default function RedshiftSQLEditor({ query, onChange }: RawEditorProps) {
+export default function RedshiftSQLEditor({ query, datasource, onChange }: RawEditorProps) {
+  const getTables = useCallback(
+    async (schema?: string) => {
+      const tables: string[] = await datasource.postResource('tables', {
+        // if schema is provided in the raw sql use that. if not, use schema defined in the query builder.
+        schema: schema ?? query.schema,
+      });
+      return tables.map((table) => ({ name: table, completion: table }));
+    },
+    [query.schema]
+  );
+
+  const getColumns = useCallback(
+    async (tableName?: string, schema?: string) => {
+      const columns: string[] = await datasource.postResource('columns', {
+        // if schema and table have been provided in the raw sql use that. if not, use schema/table defined in the query builder.
+        schema: schema ?? query.schema,
+        table: tableName ?? query.table,
+      });
+      return columns.map((column) => ({ name: column, completion: column }));
+    },
+    [query.schema]
+  );
+
+  const getColumnsRef = useRef(getColumns);
+  const getTablesRef = useRef(getTables);
+  const completionProvider = useMemo(
+    () => getRedshiftCompletionProvider({ getTables: getTablesRef, getColumns: getColumnsRef }),
+    []
+  );
+
   return (
     <SQLEditor
       query={query.rawSQL}
       onChange={(rawSQL) => onChange({ ...query, rawSQL })}
-      language={redshiftLanguageDefinition}
+      language={{
+        ...redshiftLanguageDefinition,
+        completionProvider,
+      }}
     ></SQLEditor>
   );
 }

--- a/src/language/completionItemProvider.ts
+++ b/src/language/completionItemProvider.ts
@@ -1,0 +1,31 @@
+import {
+  ColumnDefinition,
+  getStandardSQLCompletionProvider,
+  LanguageCompletionProvider,
+  TableDefinition,
+  TableIdentifier,
+  // getStandardSQLCompletionProvider,
+} from '@grafana/experimental';
+
+interface CompletionProviderGetterArgs {
+  getColumns: React.MutableRefObject<(table: string, schema?: string) => Promise<ColumnDefinition[]>>;
+  getTables: React.MutableRefObject<(d?: string) => Promise<TableDefinition[]>>;
+}
+
+export const getRedshiftCompletionProvider: (args: CompletionProviderGetterArgs) => LanguageCompletionProvider =
+  ({ getColumns, getTables }) =>
+  (monaco, language) => {
+    return {
+      // get standard SQL completion provider which will resolve functions and macros
+      ...(language && getStandardSQLCompletionProvider(monaco, language)),
+      triggerCharacters: ['.', ' ', '$', ',', '(', "'"],
+      tables: {
+        resolve: async (t: TableIdentifier) => {
+          return await getTables.current(t?.schema);
+        },
+      },
+      columns: {
+        resolve: async (t: TableIdentifier) => getColumns.current(t.table!, t.schema),
+      },
+    };
+  };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1218,10 +1218,10 @@
     prettier "2.2.1"
     typescript "4.2.4"
 
-"@grafana/experimental@^0.0.2-canary.33":
-  version "0.0.2-canary.33"
-  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-0.0.2-canary.33.tgz#9d9b15b5dc53058964fcab1a14f860a87139267c"
-  integrity sha512-5Evp/VLlJcH8Rj6v6excBmJxJlG2w0EAKlDNu1Ft8t1nKj9YECH/bpmxoO/itrmAEf8pJ6ZHuoPu4caHv7KqwQ==
+"@grafana/experimental@^0.0.2-canary.37":
+  version "0.0.2-canary.37"
+  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-0.0.2-canary.37.tgz#3440aeff2d73782842f03655747d7e3e7f41007a"
+  integrity sha512-wXY3hoFNPi6sONpOVzb8Hd7fR3G592oYSwk+qjgy3bImoLBLHVubV04g1Zerj5DXypFsJ101daX7Xk7PhK7DWw==
   dependencies:
     "@types/uuid" "^8.3.3"
     uuid "^8.3.2"


### PR DESCRIPTION
This PR adds a custom completion item provider that resolves table names and columns names specific for the redshift data source. 

![tableandschema](https://user-images.githubusercontent.com/2388950/184825722-e357d321-84ee-46ae-a090-bfc6b3de0e5e.gif)

Part of #108
Fixes #168