### PR TITLE
Provide suggestions for schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@grafana/runtime": "8.0.5",
     "@grafana/toolkit": "8.0.5",
     "@grafana/ui": "8.0.5",
-    "@grafana/experimental": "^0.0.2-canary.33",
+    "@grafana/experimental": "^0.0.2-canary.37",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",
     "@testing-library/user-event": "^13.1.9",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@grafana/runtime": "8.0.5",
     "@grafana/toolkit": "8.0.5",
     "@grafana/ui": "8.0.5",
-    "@grafana/experimental": "^0.0.2-canary.37",
+    "@grafana/experimental": "^0.0.2-canary.39",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",
     "@testing-library/user-event": "^13.1.9",

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -4,7 +4,7 @@ import { config } from '@grafana/runtime';
 import { InlineSegmentGroup } from '@grafana/ui';
 import React from 'react';
 import { selectors } from 'selectors';
-import RedshiftSQLEditor from 'RedshiftSQLEditor';
+import SQLEditor from './SQLEditor';
 import { getSuggestions } from 'Suggestions';
 
 import { DataSource } from './datasource';
@@ -95,7 +95,7 @@ export function QueryEditor(props: Props) {
         </div>
         <div style={{ minWidth: '400px', marginLeft: '10px', flex: 1 }}>
           {config.featureToggles.redshiftExperimentalUI ? (
-            <RedshiftSQLEditor query={props.query} onChange={props.onChange} datasource={props.datasource} />
+            <SQLEditor query={props.query} onChange={props.onChange} datasource={props.datasource} />
           ) : (
             <QueryCodeEditor
               language="redshift"

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -95,7 +95,7 @@ export function QueryEditor(props: Props) {
         </div>
         <div style={{ minWidth: '400px', marginLeft: '10px', flex: 1 }}>
           {config.featureToggles.redshiftExperimentalUI ? (
-            <RedshiftSQLEditor query={props.query} onChange={props.onChange} />
+            <RedshiftSQLEditor query={props.query} onChange={props.onChange} datasource={props.datasource} />
           ) : (
             <QueryCodeEditor
               language="redshift"

--- a/src/RedshiftSQLEditor/index.tsx
+++ b/src/RedshiftSQLEditor/index.tsx
@@ -12,6 +12,11 @@ interface RawEditorProps {
 }
 
 export default function RedshiftSQLEditor({ query, datasource, onChange }: RawEditorProps) {
+  const getSchemas = useCallback(async () => {
+    const schemas: string[] = await datasource.postResource('schemas');
+    return schemas.map((schema) => ({ name: schema, completion: schema }));
+  }, [query.schema]);
+
   const getTables = useCallback(
     async (schema?: string) => {
       const tables: string[] = await datasource.postResource('tables', {
@@ -35,10 +40,12 @@ export default function RedshiftSQLEditor({ query, datasource, onChange }: RawEd
     [query.schema]
   );
 
-  const getColumnsRef = useRef(getColumns);
+  const getSchemasRef = useRef(getSchemas);
   const getTablesRef = useRef(getTables);
+  const getColumnsRef = useRef(getColumns);
   const completionProvider = useMemo(
-    () => getRedshiftCompletionProvider({ getTables: getTablesRef, getColumns: getColumnsRef }),
+    () =>
+      getRedshiftCompletionProvider({ getTables: getTablesRef, getColumns: getColumnsRef, getSchemas: getSchemasRef }),
     []
   );
 

--- a/src/RedshiftSQLEditor/index.tsx
+++ b/src/RedshiftSQLEditor/index.tsx
@@ -1,7 +1,9 @@
 import { SQLEditor } from '@grafana/experimental';
+import { getTemplateSrv } from '@grafana/runtime';
 import { DataSource } from 'datasource';
 import { getRedshiftCompletionProvider } from 'language/completionItemProvider';
 import redshiftLanguageDefinition from 'language/definition';
+import { SCHEMA_MACRO, TABLE_MACRO } from 'language/macros';
 import React, { useRef, useMemo, useCallback } from 'react';
 import { RedshiftQuery } from 'types';
 
@@ -12,6 +14,18 @@ interface RawEditorProps {
 }
 
 export default function RedshiftSQLEditor({ query, datasource, onChange }: RawEditorProps) {
+  const interpolate = (value: string | undefined) => {
+    if (!value) {
+      return value;
+    }
+
+    value = value.replace(SCHEMA_MACRO, query.schema ?? '');
+    value = value.replace(TABLE_MACRO, query.table ?? '');
+    value = getTemplateSrv().replace(value);
+
+    return value;
+  };
+
   const getSchemas = useCallback(async () => {
     const schemas: string[] = await datasource.postResource('schemas');
     return schemas.map((schema) => ({ name: schema, completion: schema }));
@@ -21,7 +35,7 @@ export default function RedshiftSQLEditor({ query, datasource, onChange }: RawEd
     async (schema?: string) => {
       const tables: string[] = await datasource.postResource('tables', {
         // if schema is provided in the raw sql use that. if not, use schema defined in the query builder.
-        schema: schema ?? query.schema,
+        schema: interpolate(schema) ?? query.schema,
       });
       return tables.map((table) => ({ name: table, completion: table }));
     },
@@ -32,8 +46,8 @@ export default function RedshiftSQLEditor({ query, datasource, onChange }: RawEd
     async (tableName?: string, schema?: string) => {
       const columns: string[] = await datasource.postResource('columns', {
         // if schema and table have been provided in the raw sql use that. if not, use schema/table defined in the query builder.
-        schema: schema ?? query.schema,
-        table: tableName ?? query.table,
+        schema: interpolate(schema) ?? query.schema,
+        table: interpolate(tableName) ?? query.table,
       });
       return columns.map((column) => ({ name: column, completion: column }));
     },

--- a/src/RedshiftSQLEditor/index.tsx
+++ b/src/RedshiftSQLEditor/index.tsx
@@ -1,19 +1,55 @@
 import { SQLEditor } from '@grafana/experimental';
+import { DataSource } from 'datasource';
+import { getRedshiftCompletionProvider } from 'language/completionItemProvider';
 import redshiftLanguageDefinition from 'language/definition';
-import React from 'react';
+import React, { useRef, useMemo, useCallback } from 'react';
 import { RedshiftQuery } from 'types';
 
 interface RawEditorProps {
   query: RedshiftQuery;
   onChange: (q: RedshiftQuery) => void;
+  datasource: DataSource;
 }
 
-export default function RedshiftSQLEditor({ query, onChange }: RawEditorProps) {
+export default function RedshiftSQLEditor({ query, datasource, onChange }: RawEditorProps) {
+  const getTables = useCallback(
+    async (schema?: string) => {
+      const tables: string[] = await datasource.postResource('tables', {
+        // if schema is provided in the raw sql use that. if not, use schema defined in the query builder.
+        schema: schema ?? query.schema,
+      });
+      return tables.map((table) => ({ name: table, completion: table }));
+    },
+    [query.schema]
+  );
+
+  const getColumns = useCallback(
+    async (tableName?: string, schema?: string) => {
+      const columns: string[] = await datasource.postResource('columns', {
+        // if schema and table have been provided in the raw sql use that. if not, use schema/table defined in the query builder.
+        schema: schema ?? query.schema,
+        table: tableName ?? query.table,
+      });
+      return columns.map((column) => ({ name: column, completion: column }));
+    },
+    [query.schema]
+  );
+
+  const getColumnsRef = useRef(getColumns);
+  const getTablesRef = useRef(getTables);
+  const completionProvider = useMemo(
+    () => getRedshiftCompletionProvider({ getTables: getTablesRef, getColumns: getColumnsRef }),
+    []
+  );
+
   return (
     <SQLEditor
       query={query.rawSQL}
       onChange={(rawSQL) => onChange({ ...query, rawSQL })}
-      language={redshiftLanguageDefinition}
+      language={{
+        ...redshiftLanguageDefinition,
+        completionProvider,
+      }}
     ></SQLEditor>
   );
 }

--- a/src/language/completionItemProvider.ts
+++ b/src/language/completionItemProvider.ts
@@ -1,0 +1,31 @@
+import {
+  ColumnDefinition,
+  getStandardSQLCompletionProvider,
+  LanguageCompletionProvider,
+  TableDefinition,
+  TableIdentifier,
+  // getStandardSQLCompletionProvider,
+} from '@grafana/experimental';
+
+interface CompletionProviderGetterArgs {
+  getColumns: React.MutableRefObject<(table: string, schema?: string) => Promise<ColumnDefinition[]>>;
+  getTables: React.MutableRefObject<(d?: string) => Promise<TableDefinition[]>>;
+}
+
+export const getRedshiftCompletionProvider: (args: CompletionProviderGetterArgs) => LanguageCompletionProvider =
+  ({ getColumns, getTables }) =>
+  (monaco, language) => {
+    return {
+      // get standard SQL completion provider which will resolve functions and macros
+      ...(language && getStandardSQLCompletionProvider(monaco, language)),
+      triggerCharacters: ['.', ' ', '$', ',', '(', "'"],
+      tables: {
+        resolve: async (t: TableIdentifier) => {
+          return await getTables.current(t?.schema);
+        },
+      },
+      columns: {
+        resolve: async (t: TableIdentifier) => getColumns.current(t.table!, t.schema),
+      },
+    };
+  };

--- a/src/language/completionItemProvider.ts
+++ b/src/language/completionItemProvider.ts
@@ -6,6 +6,7 @@ import {
   TableIdentifier,
   // getStandardSQLCompletionProvider,
 } from '@grafana/experimental';
+import { MACROS } from './macros';
 
 interface CompletionProviderGetterArgs {
   getColumns: React.MutableRefObject<(table: string, schema?: string) => Promise<ColumnDefinition[]>>;
@@ -27,5 +28,6 @@ export const getRedshiftCompletionProvider: (args: CompletionProviderGetterArgs)
       columns: {
         resolve: async (t: TableIdentifier) => getColumns.current(t.table!, t.schema),
       },
+      supportedMacros: () => MACROS,
     };
   };

--- a/src/language/completionItemProvider.ts
+++ b/src/language/completionItemProvider.ts
@@ -4,22 +4,27 @@ import {
   LanguageCompletionProvider,
   TableDefinition,
   TableIdentifier,
+  SchemaDefinition,
   // getStandardSQLCompletionProvider,
 } from '@grafana/experimental';
 import { MACROS } from './macros';
 
 interface CompletionProviderGetterArgs {
+  getSchemas: React.MutableRefObject<() => Promise<TableDefinition[]>>;
+  getTables: React.MutableRefObject<(d?: string) => Promise<SchemaDefinition[]>>;
   getColumns: React.MutableRefObject<(table: string, schema?: string) => Promise<ColumnDefinition[]>>;
-  getTables: React.MutableRefObject<(d?: string) => Promise<TableDefinition[]>>;
 }
 
 export const getRedshiftCompletionProvider: (args: CompletionProviderGetterArgs) => LanguageCompletionProvider =
-  ({ getColumns, getTables }) =>
+  ({ getSchemas, getTables, getColumns }) =>
   (monaco, language) => {
     return {
       // get standard SQL completion provider which will resolve functions and macros
       ...(language && getStandardSQLCompletionProvider(monaco, language)),
       triggerCharacters: ['.', ' ', '$', ',', '(', "'"],
+      schemas: {
+        resolve: async () => getSchemas.current(),
+      },
       tables: {
         resolve: async (t: TableIdentifier) => {
           return await getTables.current(t?.schema);

--- a/src/language/completionItemProvider.ts
+++ b/src/language/completionItemProvider.ts
@@ -5,7 +5,6 @@ import {
   TableDefinition,
   TableIdentifier,
   SchemaDefinition,
-  // getStandardSQLCompletionProvider,
 } from '@grafana/experimental';
 import { MACROS } from './macros';
 

--- a/src/language/macros.ts
+++ b/src/language/macros.ts
@@ -1,0 +1,100 @@
+import { MacroType } from '@grafana/experimental';
+
+const COLUMN = 'column',
+  RELATIVE_TIME_STRING = "'1m'";
+
+export const MACROS = [
+  {
+    id: '$__timeFilter(dateColumn)',
+    name: '$__timeFilter(dateColumn)',
+    text: '$__timeFilter',
+    args: [COLUMN],
+    type: MacroType.Filter,
+    description:
+      "Will be replaced by a time range filter using the specified column name. For example, time BETWEEN '2017-07-18T11:15:52Z' AND '2017-07-18T11:15:52Z'",
+  },
+  {
+    id: '$__timeFrom()',
+    name: '$__timeFrom()',
+    text: '$__timeFrom',
+    args: [],
+    type: MacroType.Filter,
+    description:
+      "Will be replaced by the start of the currently active time selection. For example, '2017-07-18T11:15:52Z'",
+  },
+  {
+    id: '$__timeTo()',
+    name: '$__timeTo()',
+    text: '$__timeTo',
+    args: [],
+    type: MacroType.Filter,
+    description:
+      "Will be replaced by the end of the currently active time selection. For example, '2017-07-18T11:15:52Z'",
+  },
+  {
+    id: '$__timeEpoch()',
+    name: '$__timeEpoch()',
+    text: '$__timeEpoch',
+    args: [COLUMN],
+    type: MacroType.Filter,
+    description:
+      'Will be replaced by an expression to convert to a UNIX timestamp and rename the column to time. For example, UNIX_TIMESTAMP(dateColumn) as "time"',
+  },
+  {
+    id: '$__unixEpochFilter()',
+    name: '$__unixEpochFilter()',
+    text: '$__unixEpochFilter',
+    args: [COLUMN],
+    type: MacroType.Filter,
+    description:
+      'Will be replaced by a time range filter using the specified column name with times represented as Unix timestamp. For example, column >= 1624406400 AND column <= 1624410000',
+  },
+  {
+    id: "$__timeGroup(dateColumn, '1m')",
+    name: "$__timeGroup(dateColumn, '1m')",
+    text: '$__timeGroup',
+    args: [COLUMN, RELATIVE_TIME_STRING],
+    type: MacroType.Group,
+    description: `Will be replace by an expression that will group timestamps so that there is only 1 point for every period on the graph. For example, 'floor(extract(epoch from time)/60)*60 AS "time"'`,
+  },
+  {
+    id: "$__unixEpochGroup(dateColumn, '1m')",
+    name: "$__unixEpochGroup(dateColumn, '1m')",
+    text: '$__unixEpochGroup',
+    args: [COLUMN, RELATIVE_TIME_STRING],
+    type: MacroType.Group,
+    description: `Will be replace by an expression that will group epoch timestamps so that there is only 1 point for every period on the graph. For example, 'floor(time/60)*60 AS "time"'`,
+  },
+  {
+    id: '$__table',
+    name: '$__table',
+    text: '$__table',
+    args: [],
+    type: MacroType.Table,
+    description: 'Will be replaced by the query table.',
+  },
+  {
+    id: '$__column',
+    name: '$__column',
+    text: '$__column',
+    args: [],
+    type: MacroType.Column,
+    description: 'Will be replaced by the query column.',
+  },
+  {
+    id: '$__table',
+    name: '$__table',
+    text: '$__table',
+    args: [],
+    type: MacroType.Table,
+    description: 'Will be replaced by the query table.',
+  },
+  {
+    id: '$__schema',
+    name: '$__schema',
+    text: '$__schema',
+    args: [],
+    type: MacroType.Table,
+    description: 'Will be replaced by the query schema.',
+  },
+];

--- a/src/language/macros.ts
+++ b/src/language/macros.ts
@@ -3,6 +3,9 @@ import { MacroType } from '@grafana/experimental';
 const COLUMN = 'column',
   RELATIVE_TIME_STRING = "'1m'";
 
+export const SCHEMA_MACRO = '$__schema';
+export const TABLE_MACRO = '$__table';
+
 export const MACROS = [
   {
     id: '$__timeFilter(dateColumn)',
@@ -66,14 +69,6 @@ export const MACROS = [
     description: `Will be replace by an expression that will group epoch timestamps so that there is only 1 point for every period on the graph. For example, 'floor(time/60)*60 AS "time"'`,
   },
   {
-    id: '$__table',
-    name: '$__table',
-    text: '$__table',
-    args: [],
-    type: MacroType.Table,
-    description: 'Will be replaced by the query table.',
-  },
-  {
     id: '$__column',
     name: '$__column',
     text: '$__column',
@@ -82,17 +77,17 @@ export const MACROS = [
     description: 'Will be replaced by the query column.',
   },
   {
-    id: '$__table',
-    name: '$__table',
-    text: '$__table',
+    id: TABLE_MACRO,
+    name: TABLE_MACRO,
+    text: TABLE_MACRO,
     args: [],
     type: MacroType.Table,
     description: 'Will be replaced by the query table.',
   },
   {
-    id: '$__schema',
-    name: '$__schema',
-    text: '$__schema',
+    id: SCHEMA_MACRO,
+    name: SCHEMA_MACRO,
+    text: SCHEMA_MACRO,
     args: [],
     type: MacroType.Table,
     description: 'Will be replaced by the query schema.',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1218,10 +1218,10 @@
     prettier "2.2.1"
     typescript "4.2.4"
 
-"@grafana/experimental@^0.0.2-canary.33":
-  version "0.0.2-canary.33"
-  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-0.0.2-canary.33.tgz#9d9b15b5dc53058964fcab1a14f860a87139267c"
-  integrity sha512-5Evp/VLlJcH8Rj6v6excBmJxJlG2w0EAKlDNu1Ft8t1nKj9YECH/bpmxoO/itrmAEf8pJ6ZHuoPu4caHv7KqwQ==
+"@grafana/experimental@^0.0.2-canary.37":
+  version "0.0.2-canary.37"
+  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-0.0.2-canary.37.tgz#3440aeff2d73782842f03655747d7e3e7f41007a"
+  integrity sha512-wXY3hoFNPi6sONpOVzb8Hd7fR3G592oYSwk+qjgy3bImoLBLHVubV04g1Zerj5DXypFsJ101daX7Xk7PhK7DWw==
   dependencies:
     "@types/uuid" "^8.3.3"
     uuid "^8.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1218,10 +1218,10 @@
     prettier "2.2.1"
     typescript "4.2.4"
 
-"@grafana/experimental@^0.0.2-canary.37":
-  version "0.0.2-canary.37"
-  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-0.0.2-canary.37.tgz#3440aeff2d73782842f03655747d7e3e7f41007a"
-  integrity sha512-wXY3hoFNPi6sONpOVzb8Hd7fR3G592oYSwk+qjgy3bImoLBLHVubV04g1Zerj5DXypFsJ101daX7Xk7PhK7DWw==
+"@grafana/experimental@^0.0.2-canary.39":
+  version "0.0.2-canary.39"
+  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-0.0.2-canary.39.tgz#943ae5012114d743af1e3e7954c5df19301d6c91"
+  integrity sha512-fNKpiqZc2NWI5bUk1ybeCfQlCDao58Vb7P6wupwFLvJwi8M9tuwvxQ1Mxp1JDyFFtoBf0s12mE25tyWorA2PPA==
   dependencies:
     "@types/uuid" "^8.3.3"
     uuid "^8.3.2"


### PR DESCRIPTION
This PR is based on https://github.com/grafana/redshift-datasource/pull/169 so for the time being it includes its diff. 

This PR adds a method for resolving SQL schemas. The method is used by the autocompletion engine in grafana experimental to provide context aware suggestions for schemas. See example below.

![schemas](https://user-images.githubusercontent.com/2388950/184880745-185aa53d-9e88-476b-bd02-d26eea4c2e0c.gif)

Currently this PR is pointing to a locally linked version of grafana/experimental. Will change that as soon as [this](https://github.com/grafana/grafana-experimental/pull/46) PR has been merged.

Part of #108
Fixes #172 