### PR TITLE
Show stop query button only for async queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "dependencies": {
-    "@grafana/async-query-data": "0.0.3",
+    "@grafana/async-query-data": "0.0.4",
     "@grafana/experimental": "^0.0.2-canary.39"
   },
   "devDependencies": {

--- a/src/QueryEditor.test.tsx
+++ b/src/QueryEditor.test.tsx
@@ -11,17 +11,19 @@ import * as experimental from '@grafana/experimental';
 import { mockDatasource, mockQuery } from './__mocks__/datasource';
 import { QueryEditor } from './QueryEditor';
 
-jest.spyOn(runtime, 'getTemplateSrv').mockImplementation(() => ({
-  getVariables: jest.fn().mockReturnValue([]),
-  replace: jest.fn(),
-  containsTemplate: jest.fn(),
-  updateTimeRange: jest.fn(),
-}));
-
 jest.mock('@grafana/experimental', () => ({
   ...jest.requireActual<typeof experimental>('@grafana/experimental'),
   SQLEditor: function SQLEditor() {
     return <></>;
+  },
+}));
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual<typeof runtime>('@grafana/runtime'),
+  config: {
+    featureToggles: {
+      redshiftAsyncQueryDataSupport: true,
+    },
   },
 }));
 

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -2,6 +2,7 @@ import { FillValueSelect, FormatSelect, ResourceSelector } from '@grafana/aws-sd
 import { RunQueryButtons } from '@grafana/async-query-data';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { InlineSegmentGroup } from '@grafana/ui';
+import { config } from '@grafana/runtime';
 import React from 'react';
 import { selectors } from 'selectors';
 import SQLEditor from './SQLEditor';
@@ -98,7 +99,9 @@ export function QueryEditor(props: Props) {
                 state={props.data?.state}
                 query={props.query}
                 onRunQuery={props.onRunQuery}
-                onCancelQuery={props.datasource.cancel}
+                onCancelQuery={
+                  config.featureToggles.redshiftAsyncQueryDataSupport ? props.datasource.cancel : undefined
+                }
                 isQueryValid={isQueryValid}
               />
             </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2291,10 +2291,10 @@
   dependencies:
     tslib "2.4.0"
 
-"@grafana/async-query-data@0.0.3":
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/@grafana/async-query-data/-/async-query-data-0.0.3.tgz#735781519bf045fe1c5ba0735561c9e6945ecc38"
-  integrity sha512-HRZb6Yq4Ve5R38B4dsJu0zWgttROunT1daWOqsAdvEBuP02mUoqaB8Jf/QK/6rjvZJ9Qve8gl5iI3zHEdN0HMA==
+"@grafana/async-query-data@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/@grafana/async-query-data/-/async-query-data-0.0.4.tgz#e706439eb7af507344929ff8473c85794f2adaf0"
+  integrity sha512-EhWRofcBpwETO081zL5lXSVUbGrc4OU4YxswqeY5jhzsB8xFFOGh8GF+Z5Qeqdr+JBYjpOGsh+KaQwXlZZufAQ==
   dependencies:
     tslib "^2.4.1"
 


### PR DESCRIPTION
Renders the stop query button only when async query data support is enabled. This is the [PR](https://github.com/grafana/grafana-async-query-data-js/pull/5) that makes the stop button optional.