### PR TITLE
Update code coverage in workfkflow to latest

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -5,7 +5,7 @@ jobs:
   workflow-call:
     if: |
       !startsWith(github.head_ref, 'dependabot')
-    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.10
+    uses: grafana/code-coverage/.github/workflows/code-coverage.yml@v0.1.13
     with:
       frontend-path-regexp: src
       backend-path-regexp: pkg\/redshift


### PR DESCRIPTION
Update cc workflow to use the latest version running in Node 16: https://github.com/grafana/code-coverage/pull/21