### PR TITLE
Remove run and cancel buttons in annotations editor

### DIFF
--- a/src/AnnotationsQueryCodeEditor.tsx
+++ b/src/AnnotationsQueryCodeEditor.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { RedshiftQuery, RedshiftDataSourceOptions } from './types';
+import { QueryEditorProps } from '@grafana/data';
+import { DataSource } from 'datasource';
+import { QueryEditor } from 'QueryEditor';
+
+export function AnnotationsQueryCodeEditor(
+  props: QueryEditorProps<DataSource, RedshiftQuery, RedshiftDataSourceOptions>
+) {
+  return <QueryEditor {...props} hideRunQueryButtons></QueryEditor>;
+}

--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -1,0 +1,5 @@
+import { AnnotationsQueryCodeEditor } from './AnnotationsQueryCodeEditor';
+
+export const RedshiftAnnotationsSupport = {
+  QueryEditor: AnnotationsQueryCodeEditor,
+};

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -5,6 +5,7 @@ import { getTemplateSrv, config } from '@grafana/runtime';
 import { RedshiftVariableSupport } from 'variables';
 
 import { RedshiftDataSourceOptions, RedshiftQuery } from './types';
+import { RedshiftAnnotationsSupport } from './annotations';
 
 export class DataSource extends DatasourceWithAsyncBackend<RedshiftQuery, RedshiftDataSourceOptions> {
   constructor(instanceSettings: DataSourceInstanceSettings<RedshiftDataSourceOptions>) {
@@ -13,7 +14,7 @@ export class DataSource extends DatasourceWithAsyncBackend<RedshiftQuery, Redshi
   }
 
   // This will support annotation queries for 7.2+
-  annotations = {};
+  annotations = RedshiftAnnotationsSupport;
 
   filterQuery = filterSQLQuery;
 


### PR DESCRIPTION
In annotations editor we have 3 ways to run a query - with the buttons "Run" and "Cancel", the TEST button, as well as onBlur. This removes the extra buttons, the same as in the Redshift variable editor.

Before:
<img width="500" alt="Screen Shot 2023-01-31 at 9 31 06 AM" src="https://user-images.githubusercontent.com/16140639/215708916-7cad1d0f-6a4e-4667-bb99-4c32f42ddce1.png">

After: 
<img width="500" alt="Screen Shot 2023-01-31 at 9 34 07 AM" src="https://user-images.githubusercontent.com/16140639/215709222-103b8fb2-946b-4dc3-abb4-94604af511dc.png">

