### PR TITLE
Fix converting rows with FLOAT4 and BOOLEAN

### DIFF
--- a/pkg/redshift/driver/rows.go
+++ b/pkg/redshift/driver/rows.go
@@ -221,13 +221,13 @@ func convertRow(columns []*redshiftdataapiservice.ColumnMetadata, data []*redshi
 			}
 		case REDSHIFT_INT8:
 			ret[i] = *curr.LongValue
-		case REDSHIFT_NUMERIC, REDSHIFT_FLOAT:
+		case REDSHIFT_NUMERIC:
 			v, err := strconv.ParseFloat(*curr.StringValue, 64)
 			if err != nil {
 				return err
 			}
 			ret[i] = v
-		case REDSHIFT_FLOAT4, REDSHIFT_FLOAT8:
+		case REDSHIFT_FLOAT, REDSHIFT_FLOAT4, REDSHIFT_FLOAT8:
 			if *col.Name == "time" {
 				ret[i] = time.Unix(int64(*curr.DoubleValue), 0).UTC()
 			} else {

--- a/pkg/redshift/driver/rows.go
+++ b/pkg/redshift/driver/rows.go
@@ -221,29 +221,20 @@ func convertRow(columns []*redshiftdataapiservice.ColumnMetadata, data []*redshi
 			}
 		case REDSHIFT_INT8:
 			ret[i] = *curr.LongValue
-		case REDSHIFT_NUMERIC, REDSHIFT_FLOAT, REDSHIFT_FLOAT4:
-			bitSize := 64
-			if typeName == REDSHIFT_FLOAT4 {
-				bitSize = 32
-			}
-			v, err := strconv.ParseFloat(*curr.StringValue, bitSize)
+		case REDSHIFT_NUMERIC, REDSHIFT_FLOAT:
+			v, err := strconv.ParseFloat(*curr.StringValue, 64)
 			if err != nil {
 				return err
 			}
 			ret[i] = v
-		case REDSHIFT_FLOAT8:
+		case REDSHIFT_FLOAT4, REDSHIFT_FLOAT8:
 			if *col.Name == "time" {
 				ret[i] = time.Unix(int64(*curr.DoubleValue), 0).UTC()
 			} else {
 				ret[i] = *curr.DoubleValue
 			}
 		case REDSHIFT_BOOL:
-			// don't know why boolean values are not passed as curr.BooleanValue
-			boolValue, err := strconv.ParseBool(*curr.StringValue)
-			if err != nil {
-				return err
-			}
-			ret[i] = boolValue
+			ret[i] = *curr.BooleanValue
 
 		case REDSHIFT_CHARACTER,
 			REDSHIFT_VARCHAR,

--- a/pkg/redshift/driver/rows_test.go
+++ b/pkg/redshift/driver/rows_test.go
@@ -149,10 +149,11 @@ func Test_convertRow(t *testing.T) {
 		{
 			name: "numeric type float",
 			metadata: &redshiftdataapiservice.ColumnMetadata{
+				Name:     aws.String("other"),
 				TypeName: aws.String(REDSHIFT_FLOAT),
 			},
 			data: &redshiftdataapiservice.Field{
-				StringValue: aws.String("1.3"),
+				DoubleValue: aws.Float64(1.3),
 			},
 			expectedType:  "float64",
 			expectedValue: "1.3",

--- a/pkg/redshift/driver/rows_test.go
+++ b/pkg/redshift/driver/rows_test.go
@@ -126,13 +126,14 @@ func Test_convertRow(t *testing.T) {
 		{
 			name: "numeric type float4",
 			metadata: &redshiftdataapiservice.ColumnMetadata{
+				Name:     aws.String("other"),
 				TypeName: aws.String(REDSHIFT_FLOAT4),
 			},
 			data: &redshiftdataapiservice.Field{
-				StringValue: aws.String("1.1"),
+				DoubleValue: aws.Float64(1.1),
 			},
 			expectedType:  "float64",
-			expectedValue: "1.100000023841858",
+			expectedValue: "1.1",
 		},
 		{
 			name: "numeric type numeric",
@@ -174,7 +175,7 @@ func Test_convertRow(t *testing.T) {
 				TypeName: aws.String(REDSHIFT_BOOL),
 			},
 			data: &redshiftdataapiservice.Field{
-				StringValue: aws.String("false"),
+				BooleanValue: aws.Bool(false),
 			},
 			expectedType:  "bool",
 			expectedValue: "false",


### PR DESCRIPTION
From investigating with our external dev credentials, it looks like we were converting Float4 and Boolean from the wrong types. When I set the redshift column to the REAL type, it returned a Float4, so I don't think our issue was that we weren't supporting the type. Also, I suspect that the FLOAT type should also be converted as a double, but in Redshift it's synonymous with DOUBLE and I couldn't get it to actually return that type. 
I'm a little suspicious of the solution because it implies either that FLOAT4 has never worked or that AWS changed the return type.

Fixes #204 