### PR TITLE
Add header component to queryeditor

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@babel/core": "^7.16.7",
     "@emotion/css": "^11.1.3",
-    "@grafana/aws-sdk": "0.0.42",
+    "@grafana/aws-sdk": "0.0.44",
     "@grafana/data": "9.3.2",
     "@grafana/e2e": "9.3.2",
     "@grafana/e2e-selectors": "9.3.2",

--- a/src/AnnotationsQueryCodeEditor.tsx
+++ b/src/AnnotationsQueryCodeEditor.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { RedshiftQuery, RedshiftDataSourceOptions } from './types';
 import { QueryEditorProps } from '@grafana/data';
 import { DataSource } from 'datasource';
-import { QueryEditor } from 'QueryEditor';
+import { QueryEditorForm } from 'QueryEditorForm';
 
 export function AnnotationsQueryCodeEditor(
   props: QueryEditorProps<DataSource, RedshiftQuery, RedshiftDataSourceOptions>
 ) {
-  return <QueryEditor {...props} hideRunQueryButtons></QueryEditor>;
+  return <QueryEditorForm {...props}></QueryEditorForm>;
 }

--- a/src/QueryEditor.test.tsx
+++ b/src/QueryEditor.test.tsx
@@ -1,23 +1,29 @@
-import '@testing-library/jest-dom';
-
-import * as runtime from '@grafana/runtime';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { QueryEditor } from 'QueryEditor';
 import React from 'react';
-import { select } from 'react-select-event';
-import { FillValueOptions } from '@grafana/aws-sdk';
-import { FormatOptions } from 'types';
-import * as experimental from '@grafana/experimental';
-
 import { mockDatasource, mockQuery } from './__mocks__/datasource';
-import { QueryEditor } from './QueryEditor';
+import * as experimental from '@grafana/experimental';
+import * as runtime from '@grafana/runtime';
+import { config } from '@grafana/runtime';
+
+const ds = mockDatasource;
+const q = { ...mockQuery, rawSQL: '' };
 
 jest.mock('@grafana/experimental', () => ({
   ...jest.requireActual<typeof experimental>('@grafana/experimental'),
-  SQLEditor: function SQLEditor() {
-    return <></>;
+  SQLEditor: function SQLEditor(props: any) {
+    return (
+      <input {...props} data-testid="codeEditor" onChange={(event: any) => props.onChange(event.target.value)}></input>
+    );
   },
 }));
 
+const props = {
+  datasource: ds,
+  query: q,
+  onChange: jest.fn(),
+  onRunQuery: jest.fn(),
+};
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual<typeof runtime>('@grafana/runtime'),
   config: {
@@ -27,146 +33,39 @@ jest.mock('@grafana/runtime', () => ({
   },
 }));
 
-const ds = mockDatasource;
-const q = mockQuery;
-
 beforeEach(() => {
   ds.getResource = jest.fn().mockResolvedValue([]);
   ds.postResource = jest.fn().mockResolvedValue([]);
 });
 
-const props = {
-  datasource: ds,
-  query: q,
-  onChange: jest.fn(),
-  onRunQuery: jest.fn(),
-};
-
-describe('QueryEditor', () => {
-  it('should request select schemas but not execute the query', async () => {
-    const onChange = jest.fn();
-    const onRunQuery = jest.fn();
-    ds.getResource = jest.fn().mockResolvedValue(['foo']);
-    render(
-      <QueryEditor {...props} onChange={onChange} onRunQuery={onRunQuery} query={{ ...props.query, schema: 'bar' }} />
-    );
-
-    const selectEl = screen.getByLabelText('Schema');
-    expect(selectEl).toBeInTheDocument();
-
-    await select(selectEl, 'foo', { container: document.body });
-
-    expect(ds.getResource).toHaveBeenCalledWith('schemas');
-    expect(onChange).toHaveBeenCalledWith({
-      ...q,
-      schema: 'foo',
-    });
-    expect(onRunQuery).not.toHaveBeenCalled();
-  });
-
-  it('should request select tables but not execute the query', async () => {
-    const onChange = jest.fn();
-    const onRunQuery = jest.fn();
-    ds.postResource = jest.fn().mockResolvedValue(['foo']);
-    render(
-      <QueryEditor {...props} onChange={onChange} onRunQuery={onRunQuery} query={{ ...props.query, schema: 'bar' }} />
-    );
-
-    const selectEl = screen.getByLabelText('Table');
-    expect(selectEl).toBeInTheDocument();
-
-    await select(selectEl, 'foo', { container: document.body });
-
-    expect(ds.postResource).toHaveBeenCalledWith('tables', { schema: 'bar' });
-    expect(onChange).toHaveBeenCalledWith({
-      ...q,
-      schema: 'bar',
-      table: 'foo',
-    });
-    expect(onRunQuery).not.toHaveBeenCalled();
-  });
-
-  it('should request select column but not execute the query', async () => {
-    const onChange = jest.fn();
-    const onRunQuery = jest.fn();
-    ds.postResource = jest.fn().mockResolvedValue(['foo']);
-    render(
-      <QueryEditor {...props} onChange={onChange} onRunQuery={onRunQuery} query={{ ...props.query, table: 'bar' }} />
-    );
-
-    const selectEl = screen.getByLabelText('Column');
-    expect(selectEl).toBeInTheDocument();
-
-    await select(selectEl, 'foo', { container: document.body });
-
-    expect(ds.postResource).toHaveBeenCalledWith('columns', { table: 'bar' });
-    expect(onChange).toHaveBeenCalledWith({
-      ...q,
-      table: 'bar',
-      column: 'foo',
-    });
-    expect(onRunQuery).not.toHaveBeenCalled();
-  });
-
-  it('should include the Format As input', async () => {
+describe('Query Editor', () => {
+  it('run button should be disabled if the query is empty', () => {
     render(<QueryEditor {...props} />);
-    await waitFor(() => screen.getByText('Format as'));
-  });
-
-  it('should skip the fill mode input if the format is not TimeSeries', async () => {
-    const onChange = jest.fn();
-    render(
-      <QueryEditor
-        {...props}
-        query={{ ...props.query, format: FormatOptions.Table }}
-        queries={[]}
-        onChange={onChange}
-      />
-    );
-    await waitFor(() => screen.getByText('Format as'));
-    const selectEl = screen.queryByLabelText('Fill value');
-    expect(selectEl).not.toBeInTheDocument();
-  });
-
-  it('should allow to change the fill mode', async () => {
-    const onChange = jest.fn();
-    render(<QueryEditor {...props} queries={[]} onChange={onChange} />);
-    const selectEl = screen.getByLabelText('Fill value');
-    expect(selectEl).toBeInTheDocument();
-
-    await select(selectEl, 'NULL', { container: document.body });
-
-    expect(onChange).toHaveBeenCalledWith({
-      ...q,
-      fillMode: { mode: FillValueOptions.Null },
-    });
-  });
-
-  it('run button should be disabled if the query is not valid', () => {
-    render(<QueryEditor {...props} query={{ ...props.query, rawSQL: '' }} />);
-    const runButton = screen.getByRole('button', { name: 'Run' });
+    const runButton = screen.getByRole('button', { name: 'Run query' });
     expect(runButton).toBeDisabled();
   });
-
-  it('should run queries when the run button is clicked', () => {
-    const onChange = jest.fn();
-    const onRunQuery = jest.fn();
-    render(<QueryEditor {...props} onRunQuery={onRunQuery} onChange={onChange} />);
-    const runButton = screen.getByRole('button', { name: 'Run' });
-    expect(runButton).toBeInTheDocument();
-
-    expect(onRunQuery).not.toBeCalled();
-    fireEvent.click(runButton);
-    expect(onRunQuery).toBeCalledTimes(1);
-  });
-
-  it('stop button should be disabled until run button is clicked', () => {
+  it('should show cancel button if redshiftAsyncQueryDataSupport feature is enabled', () => {
     render(<QueryEditor {...props} />);
-    const runButton = screen.getByRole('button', { name: 'Run' });
-    const stopButton = screen.getByRole('button', { name: 'Stop' });
-    expect(stopButton).toBeInTheDocument();
-    expect(stopButton).toBeDisabled();
-    fireEvent.click(runButton);
-    expect(stopButton).not.toBeDisabled();
+    const cancelButton = screen.getByRole('button', { name: 'Stop query' });
+    expect(cancelButton).toBeInTheDocument();
+  });
+  it('should not show cancel button if redshiftAsyncQueryDataSupport feature is disabled', () => {
+    config.featureToggles.redshiftAsyncQueryDataSupport = false;
+    render(<QueryEditor {...props} />);
+    const cancelButton = screen.queryByRole('button', { name: 'Stop query' });
+    expect(cancelButton).not.toBeInTheDocument();
+  });
+  it('should re-enable Run query button if there is a change to the query', async () => {
+    render(<QueryEditor {...props} query={{ ...props.query, rawSQL: 'initial query' }} />);
+    const runButton = screen.getByRole('button', { name: 'Run query' });
+    expect(runButton).toBeDisabled();
+
+    const input = screen.getByTestId('codeEditor');
+    expect(input).toBeDefined();
+
+    fireEvent.change(input, { target: { value: 'test query' } });
+
+    expect(props.onChange).toHaveBeenCalledWith({ ...props.query, rawSQL: 'test query' });
+    expect(runButton).not.toBeDisabled();
   });
 });

--- a/src/QueryEditorForm.test.tsx
+++ b/src/QueryEditorForm.test.tsx
@@ -1,0 +1,159 @@
+import '@testing-library/jest-dom';
+
+import * as runtime from '@grafana/runtime';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { select } from 'react-select-event';
+import { FillValueOptions } from '@grafana/aws-sdk';
+import { FormatOptions } from 'types';
+import * as experimental from '@grafana/experimental';
+
+import { mockDatasource, mockQuery } from './__mocks__/datasource';
+import { QueryEditorForm } from './QueryEditorForm';
+
+jest.mock('@grafana/experimental', () => ({
+  ...jest.requireActual<typeof experimental>('@grafana/experimental'),
+  SQLEditor: function SQLEditor() {
+    return <></>;
+  },
+}));
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual<typeof runtime>('@grafana/runtime'),
+  config: {
+    featureToggles: {
+      redshiftAsyncQueryDataSupport: true,
+    },
+  },
+}));
+
+const ds = mockDatasource;
+const q = mockQuery;
+
+beforeEach(() => {
+  ds.getResource = jest.fn().mockResolvedValue([]);
+  ds.postResource = jest.fn().mockResolvedValue([]);
+});
+
+const props = {
+  datasource: ds,
+  query: q,
+  onChange: jest.fn(),
+  onRunQuery: jest.fn(),
+};
+
+describe('QueryEditorForm', () => {
+  it('should request select schemas but not execute the query', async () => {
+    const onChange = jest.fn();
+    const onRunQuery = jest.fn();
+    ds.getResource = jest.fn().mockResolvedValue(['foo']);
+    render(
+      <QueryEditorForm
+        {...props}
+        onChange={onChange}
+        onRunQuery={onRunQuery}
+        query={{ ...props.query, schema: 'bar' }}
+      />
+    );
+
+    const selectEl = screen.getByLabelText('Schema');
+    expect(selectEl).toBeInTheDocument();
+
+    await select(selectEl, 'foo', { container: document.body });
+
+    expect(ds.getResource).toHaveBeenCalledWith('schemas');
+    expect(onChange).toHaveBeenCalledWith({
+      ...q,
+      schema: 'foo',
+    });
+    expect(onRunQuery).not.toHaveBeenCalled();
+  });
+
+  it('should request select tables but not execute the query', async () => {
+    const onChange = jest.fn();
+    const onRunQuery = jest.fn();
+    ds.postResource = jest.fn().mockResolvedValue(['foo']);
+    render(
+      <QueryEditorForm
+        {...props}
+        onChange={onChange}
+        onRunQuery={onRunQuery}
+        query={{ ...props.query, schema: 'bar' }}
+      />
+    );
+
+    const selectEl = screen.getByLabelText('Table');
+    expect(selectEl).toBeInTheDocument();
+
+    await select(selectEl, 'foo', { container: document.body });
+
+    expect(ds.postResource).toHaveBeenCalledWith('tables', { schema: 'bar' });
+    expect(onChange).toHaveBeenCalledWith({
+      ...q,
+      schema: 'bar',
+      table: 'foo',
+    });
+    expect(onRunQuery).not.toHaveBeenCalled();
+  });
+
+  it('should request select column but not execute the query', async () => {
+    const onChange = jest.fn();
+    const onRunQuery = jest.fn();
+    ds.postResource = jest.fn().mockResolvedValue(['foo']);
+    render(
+      <QueryEditorForm
+        {...props}
+        onChange={onChange}
+        onRunQuery={onRunQuery}
+        query={{ ...props.query, table: 'bar' }}
+      />
+    );
+
+    const selectEl = screen.getByLabelText('Column');
+    expect(selectEl).toBeInTheDocument();
+
+    await select(selectEl, 'foo', { container: document.body });
+
+    expect(ds.postResource).toHaveBeenCalledWith('columns', { table: 'bar' });
+    expect(onChange).toHaveBeenCalledWith({
+      ...q,
+      table: 'bar',
+      column: 'foo',
+    });
+    expect(onRunQuery).not.toHaveBeenCalled();
+  });
+
+  it('should include the Format As input', async () => {
+    render(<QueryEditorForm {...props} />);
+    await waitFor(() => screen.getByText('Format as'));
+  });
+
+  it('should skip the fill mode input if the format is not TimeSeries', async () => {
+    const onChange = jest.fn();
+    render(
+      <QueryEditorForm
+        {...props}
+        query={{ ...props.query, format: FormatOptions.Table }}
+        queries={[]}
+        onChange={onChange}
+      />
+    );
+    await waitFor(() => screen.getByText('Format as'));
+    const selectEl = screen.queryByLabelText('Fill value');
+    expect(selectEl).not.toBeInTheDocument();
+  });
+
+  it('should allow to change the fill mode', async () => {
+    const onChange = jest.fn();
+    render(<QueryEditorForm {...props} queries={[]} onChange={onChange} />);
+    const selectEl = screen.getByLabelText('Fill value');
+    expect(selectEl).toBeInTheDocument();
+
+    await select(selectEl, 'NULL', { container: document.body });
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...q,
+      fillMode: { mode: FillValueOptions.Null },
+    });
+  });
+});

--- a/src/QueryEditorForm.tsx
+++ b/src/QueryEditorForm.tsx
@@ -1,0 +1,92 @@
+import { FillValueSelect, FormatSelect, ResourceSelector } from '@grafana/aws-sdk';
+import { QueryEditorProps, SelectableValue } from '@grafana/data';
+import { InlineSegmentGroup } from '@grafana/ui';
+import React from 'react';
+import { selectors } from 'selectors';
+import SQLEditor from './SQLEditor';
+
+import { DataSource } from './datasource';
+import { FormatOptions, RedshiftDataSourceOptions, RedshiftQuery, SelectableFormatOptions } from './types';
+
+type Props = QueryEditorProps<DataSource, RedshiftQuery, RedshiftDataSourceOptions>;
+
+type QueryProperties = 'schema' | 'table' | 'column';
+
+export function QueryEditorForm(props: Props) {
+  const fetchSchemas = async () => {
+    const schemas: string[] = await props.datasource.getResource('schemas');
+    return schemas.map((schema) => ({ label: schema, value: schema })).concat({ label: '-- remove --', value: '' });
+  };
+
+  const fetchTables = async () => {
+    const tables: string[] = await props.datasource.postResource('tables', {
+      schema: props.query.schema || '',
+    });
+    return tables.map((table) => ({ label: table, value: table })).concat({ label: '-- remove --', value: '' });
+  };
+
+  const fetchColumns = async () => {
+    const columns: string[] = await props.datasource.postResource('columns', {
+      schema: props.query.schema,
+      table: props.query.table,
+    });
+    return columns.map((column) => ({ label: column, value: column })).concat({ label: '-- remove --', value: '' });
+  };
+
+  const onChange = (prop: QueryProperties) => (e: SelectableValue<string> | null) => {
+    const newQuery = { ...props.query };
+    const value = e?.value;
+    newQuery[prop] = value;
+    props.onChange(newQuery);
+  };
+
+  return (
+    <>
+      <InlineSegmentGroup>
+        <div className="gf-form-group">
+          <h6>Macros</h6>
+          <ResourceSelector
+            onChange={onChange('schema')}
+            fetch={fetchSchemas}
+            value={props.query.schema || null}
+            tooltip="Use the selected schema with the $__schema macro"
+            label={selectors.components.ConfigEditor.schema.input}
+            data-testid={selectors.components.ConfigEditor.schema.testID}
+            labelWidth={11}
+            className="width-12"
+          />
+          <ResourceSelector
+            onChange={onChange('table')}
+            fetch={fetchTables}
+            value={props.query.table || null}
+            dependencies={[props.query.schema]}
+            tooltip="Use the selected table with the $__table macro"
+            label={selectors.components.ConfigEditor.table.input}
+            data-testid={selectors.components.ConfigEditor.table.testID}
+            labelWidth={11}
+            className="width-12"
+          />
+          <ResourceSelector
+            onChange={onChange('column')}
+            fetch={fetchColumns}
+            value={props.query.column || null}
+            dependencies={[props.query.table]}
+            tooltip="Use the selected column with the $__column macro"
+            label={selectors.components.ConfigEditor.column.input}
+            data-testid={selectors.components.ConfigEditor.column.testID}
+            labelWidth={11}
+            className="width-12"
+          />
+          <h6>Frames</h6>
+          <FormatSelect query={props.query} options={SelectableFormatOptions} onChange={props.onChange} />
+          {props.query.format === FormatOptions.TimeSeries && (
+            <FillValueSelect query={props.query} onChange={props.onChange} />
+          )}
+        </div>
+        <div style={{ minWidth: '400px', marginLeft: '10px', flex: 1 }}>
+          <SQLEditor query={props.query} onChange={props.onChange} datasource={props.datasource} />
+        </div>
+      </InlineSegmentGroup>
+    </>
+  );
+}

--- a/src/VariableQueryEditor.tsx
+++ b/src/VariableQueryEditor.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { RedshiftQuery, RedshiftDataSourceOptions } from './types';
 import { QueryEditorProps } from '@grafana/data';
 import { DataSource } from 'datasource';
-import { QueryEditor } from 'QueryEditor';
+import { QueryEditorForm } from 'QueryEditorForm';
 
 export function VariableQueryCodeEditor(props: QueryEditorProps<DataSource, RedshiftQuery, RedshiftDataSourceOptions>) {
-  return <QueryEditor {...props} hideRunQueryButtons></QueryEditor>;
+  return <QueryEditorForm {...props}></QueryEditorForm>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1502,10 +1502,20 @@
   dependencies:
     tslib "^2.4.1"
 
-"@grafana/aws-sdk@0.0.42":
-  version "0.0.42"
-  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.42.tgz#adfb429df990374e33b1894e39f04692c0bcb71b"
-  integrity sha512-u7UyK1wA84t8L+kKjl+xKndKhTe0KGZYEj8EsQs+AK1JD1E90l4h82zEQGZmcNS5o8LdQeItvRBYPWylbcTp4A==
+"@grafana/async-query-data@0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@grafana/async-query-data/-/async-query-data-0.1.4.tgz#ac24e32822a8032dd1ee10ce7dcb8c2e276c58b0"
+  integrity sha512-3d7fm2sf5x/+JKTt4T6MSS/veB2J/YGfQp5Ck0Tbqtc5YIoI0p1JY+vFWfCstEHyVd1H0Ep/q/VSxf4VAs9YKQ==
+  dependencies:
+    tslib "^2.4.1"
+
+"@grafana/aws-sdk@0.0.44":
+  version "0.0.44"
+  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.44.tgz#e4a351e6c04d6aa4403e57fbf7eb33946a91a647"
+  integrity sha512-L5wdKL1/eelD9urqHFzpal1fOWSx0FNOOSC5NT+t59bs3VUWrYRllccQ8EiGmAULTTMIuudSbzocaLacp6ET4A==
+  dependencies:
+    "@grafana/async-query-data" "0.1.4"
+    "@grafana/experimental" "1.1.0"
 
 "@grafana/data@9.3.2":
   version "9.3.2"
@@ -1587,6 +1597,14 @@
     eslint-plugin-react-hooks "4.3.0"
     prettier "2.5.1"
     typescript "4.4.4"
+
+"@grafana/experimental@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-1.1.0.tgz#36b9644b1e61c782ed42b4805c5e297f2cc3f8bf"
+  integrity sha512-pQhYhw+jB7Q+t8rLcd1jcx91BiFDNslBATJkNIgO9I2Bah+ww+2RH1hUGVoJNPL84vW7WRU7w9k/L7FJs7/L6Q==
+  dependencies:
+    "@types/uuid" "^8.3.3"
+    uuid "^8.3.2"
 
 "@grafana/experimental@^0.0.2-canary.39":
   version "0.0.2-canary.39"


### PR DESCRIPTION
Implements https://github.com/grafana/grafana-aws-sdk-react/issues/37

<img width="1168" alt="Screen Shot 2023-02-27 at 10 52 02 AM" src="https://user-images.githubusercontent.com/16140639/221531038-9bcda905-030a-4535-bac8-022fbd8cc6ff.png">


Basically the same as [this Athena PR](https://github.com/grafana/athena-datasource/pull/217), so I copied the tests too. 