### PR TITLE
Upgrade grafana/aws-sdk-go and version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.8.3
+
+- Upgrade grafana/aws-sdk-react to 0.0.46 https://github.com/grafana/redshift-datasource/pull/81
+
 ## 1.8.2
 
 - Update grafana-aws-sdk version to include new region in opt-in region list https://github.com/grafana/grafana-aws-sdk/pull/80 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-redshift-datasource",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Use Amazon Redshift in Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@babel/core": "^7.16.7",
     "@emotion/css": "^11.1.3",
-    "@grafana/aws-sdk": "0.0.44",
+    "@grafana/aws-sdk": "0.0.46",
     "@grafana/data": "9.3.2",
     "@grafana/e2e": "9.3.2",
     "@grafana/e2e-selectors": "9.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1509,10 +1509,10 @@
   dependencies:
     tslib "^2.4.1"
 
-"@grafana/aws-sdk@0.0.44":
-  version "0.0.44"
-  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.44.tgz#e4a351e6c04d6aa4403e57fbf7eb33946a91a647"
-  integrity sha512-L5wdKL1/eelD9urqHFzpal1fOWSx0FNOOSC5NT+t59bs3VUWrYRllccQ8EiGmAULTTMIuudSbzocaLacp6ET4A==
+"@grafana/aws-sdk@0.0.46":
+  version "0.0.46"
+  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.46.tgz#e9663e23871b25cbd34d77692071eb541308333c"
+  integrity sha512-9ea01XTom24to35gwb0V7JF7wNw4ltL39DJgGqfFIyOcHrjcMm8XvP4H7CI3hrDYMp93ouKsDC9qNXTm0On2uQ==
   dependencies:
     "@grafana/async-query-data" "0.1.4"
     "@grafana/experimental" "1.1.0"


### PR DESCRIPTION
Fixes https://github.com/grafana/oss-plugin-partnerships/issues/163 by updating grafana/aws-sdk-react version to the latest one with the [fix](https://github.com/grafana/grafana-aws-sdk-react/pull/46)