### PR TITLE
Update readme re: Grafana 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## 1.8.4
+
+- Upgrade Readme.md re: Grafana 10 https://github.com/grafana/redshift-datasource/pull/224
+
 ## 1.8.3
 
-- Upgrade grafana/aws-sdk-react to 0.0.46 https://github.com/grafana/redshift-datasource/pull/81
+- Upgrade grafana/aws-sdk-react to 0.0.46 https://github.com/grafana/redshift-datasource/pull/223
 
 ## 1.8.2
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Grafana 10 breaking change: update Redshift datasource plugin to >=2.9.3
+## Grafana 10 breaking change: update Redshift datasource plugin to >=1.8.3
 
 Grafana 10.0.0 was shipped with the new React 18 upgrade. Changes in batching of state updates in React 18 cause a bug in the query editor in Redshift versions <=1.8.2 If you’re using Grafana@>=10.0.0, please update your plugin to version 1.8.3 or higher in your Grafana instance management console.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+## Grafana 10 breaking change: update Redshift datasource plugin to >=2.9.3
+
+Grafana 10.0.0 was shipped with the new React 18 upgrade. Changes in batching of state updates in React 18 cause a bug in the query editor in Redshift versions <=1.8.2 If you’re using Grafana@>=10.0.0, please update your plugin to version 1.8.3 or higher in your Grafana instance management console.
+
+
 # Redshift data source for Grafana
 
 The Redshift data source plugin allows you to query and visualize Redshift data metrics from within Grafana.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-redshift-datasource",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Use Amazon Redshift in Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
This should make sure we have more visibility on the bugfix, since the Readme.md is displayed in the plugin details page: https://grafana.com/grafana/plugins/grafana-redshift-datasource (that the customer can get to from their "installed plugins" overview)

I put it at the top, but lmk if I should move it