### PR TITLE
Support async query caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,3 +257,7 @@ Imported dashboards can be found in Configuration > Data Sources > select your R
 Async Query Data support enables an asynchronous query handling flow. With Async Query Data support enabled, queries will be handled over multiple requests (starting, checking its status, and fetching the results) instead of having a query be started and resolved over a single request. This is useful for queries that can potentially run for a long time and timeout.
 
 To enable async query data support, you need to set feature toggle `redshiftAsyncQueryDataSupport` to `true`. Here are instructions to [configure feature toggles](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#feature_toggles). You'll also need to ensure the IAM policy used by Grafana allows the following actions `redshift-data:ListStatements` and `redshift-data:CancelStatement`.
+
+### Async Query Caching
+
+To enable [query caching](https://grafana.com/docs/grafana/latest/administration/data-source-management/#query-caching) for async queries, you need to be on Grafana version 10.1 or above, and to set the feature toggles `useCachingService` and `awsAsyncQueryCaching` to `true`. You'll also need to [configure query caching](https://grafana.com/docs/grafana/latest/administration/data-source-management/#query-caching) for the specific Redshift datasource.

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/aws/aws-sdk-go v1.44.245
 	github.com/google/go-cmp v0.5.9
-	github.com/grafana/grafana-aws-sdk v0.15.1
+	github.com/grafana/grafana-aws-sdk v0.16.1
 	github.com/grafana/grafana-plugin-sdk-go v0.161.0
 	github.com/grafana/sqlds/v2 v2.3.10
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2z
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/grafana/grafana-aws-sdk v0.15.1 h1:OVGTCSpR40BXol+KgLkWZJzc5sNgKmZheYB6j+aE14E=
-github.com/grafana/grafana-aws-sdk v0.15.1/go.mod h1:rCXLYoMpPqF90U7XqgVJ1HIAopFVF0bB3SXBVEJIm3I=
+github.com/grafana/grafana-aws-sdk v0.16.1 h1:R/hMtQP7H0+8nWFoIOApaZj0qstmZM+5Pw0rRzk3A3Y=
+github.com/grafana/grafana-aws-sdk v0.16.1/go.mod h1:rCXLYoMpPqF90U7XqgVJ1HIAopFVF0bB3SXBVEJIm3I=
 github.com/grafana/grafana-plugin-sdk-go v0.94.0/go.mod h1:3VXz4nCv6wH5SfgB3mlW39s+c+LetqSCjFj7xxPC5+M=
 github.com/grafana/grafana-plugin-sdk-go v0.161.0 h1:UjVjRGQ5cuT4Ok30qUeLW2OhQhx9Whuz9Oz/1KsBvVM=
 github.com/grafana/grafana-plugin-sdk-go v0.161.0/go.mod h1:dPhljkVno3Bg/ZYafMrR/BfYjtCRJD2hU2719Nl3QzM=

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "dependencies": {
-    "@grafana/async-query-data": "0.1.6",
+    "@grafana/async-query-data": "0.1.9",
     "@grafana/experimental": "^0.0.2-canary.39"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1502,10 +1502,10 @@
   dependencies:
     tslib "^2.4.1"
 
-"@grafana/async-query-data@0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@grafana/async-query-data/-/async-query-data-0.1.6.tgz#2de218afba9a08bdece3d906c67fa51d331fb8e2"
-  integrity sha512-KH6JQiM0JPqP6STk4TCRF36DbNrZxwelDLrDr9tvqYXJ6K7T+Q/7+INtsP9XBZjf4I8No1OeJxYeT5iUUYFxag==
+"@grafana/async-query-data@0.1.9":
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/@grafana/async-query-data/-/async-query-data-0.1.9.tgz#f366247a26f5353dc48ab24e1521fa1bed00f528"
+  integrity sha512-qjWNAM2nhTdrdCLBwfhX4jt783k2lqfzptAz1wqQj6E0mJgzGkSKdomdDwU8ZLtokeld/FT5jqzVXTXb3nKScg==
   dependencies:
     tslib "^2.4.1"
 


### PR DESCRIPTION
Updates the dependencies to the versions that support async query caching.

Note that to enable it you need to use enterprise Grafana version 10.1.x, with caching turned on for the Redshift datasource and useCachingService = true and awsAsyncQueryCaching = true in the custom.ini.

Fixes #232 