### PR TITLE
README: fix Condition in IAM policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ Here is a minimal policy example:
       "Sid": "AllowReadingRedshiftQuerySecrets",
       "Effect": "Allow",
       "Action": ["secretsmanager:GetSecretValue"],
-      "Resource": "*",
+      "Resource": "",
       "Condition": {
         "Null": {
-          "secretsmanager:ResourceTag/RedshiftQueryOwner": "false"
+          "secretsmanager:ResourceTag/RedshiftQueryOwner": ""
         }
       }
     }


### PR DESCRIPTION
Hello community,

I'm updating the IAM policy from README to reflect the actual way how the datasource is accessing secrets, [reference](https://github.com/grafana/redshift-datasource/blob/11425dc03d1fd0b17dad5a0a69ea476a368b0f81/pkg/redshift/api/api.go#L372)