### PR TITLE
Upgrade grafana/aws-sdk-react dependency and prepare release 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.11.0
+
+- Upgrade grafana/aws-sdk-react dependency [#239](https://github.com/grafana/redshift-datasource/pull/236)
+- Fix connection error when changing access and secret key [#235](https://github.com/grafana/redshift-datasource/pull/235)
+- Support async query caching [#233](https://github.com/grafana/redshift-datasource/pull/233)
+
 ## 1.10.0
 
 - Add support for Redshift Serverless https://github.com/grafana/redshift-datasource/pull/228 by @yota-p

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-redshift-datasource",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Use Amazon Redshift in Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "@babel/core": "^7.16.7",
     "@emotion/css": "^11.1.3",
-    "@grafana/aws-sdk": "0.0.47",
+    "@grafana/aws-sdk": "0.0.48",
     "@grafana/data": "9.3.2",
     "@grafana/e2e": "9.3.2",
     "@grafana/e2e-selectors": "9.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1509,10 +1509,10 @@
   dependencies:
     tslib "^2.4.1"
 
-"@grafana/aws-sdk@0.0.47":
-  version "0.0.47"
-  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.47.tgz#2150acd3a39c7c1639eac827c553a8bc440d514a"
-  integrity sha512-7SvIJFg0E9IhO+OogQH9p/Nte81XDGqiy1ru8rv7XoFFt1NFGTGxNUCsamOMX32mMNo2m91jHaifj5ZrMYeT/g==
+"@grafana/aws-sdk@0.0.48":
+  version "0.0.48"
+  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.0.48.tgz#8831b7dc21d4b338b324a22bcaaccde116cd28bb"
+  integrity sha512-lh6aWRoHw0wlkFKY2Qhb3du6iElA2oOtwsMuTmr3urZPTfMhJEzCPkiA/pWYzZHmKaIeez/EYECirQ16k7pW/w==
   dependencies:
     "@grafana/async-query-data" "0.1.4"
     "@grafana/experimental" "1.1.0"


### PR DESCRIPTION
While testing sandboxing, @kevinwcyu got errors related to use of grafanaBootData in Redshift's version of aws-sdk. The package has previously been updated to use config instead of grafanaBootData, so this is just to update the dependency to contain the new code.