### PR TITLE
Fix `type` in provisioning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ apiVersion: 1
 
 datasources:
   - name: Redshift
-    type: redshift
+    type: grafana-redshift-datasource
     jsonData:
       authType: keys
       defaultRegion: eu-west-2
@@ -236,7 +236,7 @@ datasources:
 apiVersion: 1
 datasources:
   - name: Redshift
-    type: redshift
+    type: grafana-redshift-datasource
     jsonData:
       authType: default
       assumeRoleArn: arn:aws:iam::123456789012:root


### PR DESCRIPTION
The README suggests to use as data source type 'redshift', which, however, does not work. 

https://github.com/grafana/redshift-datasource/blob/aca203cfd0648ea0fd82a70a9c11266de7daeed8/README.md#L224

The correct type is `grafana-redshift-datasource`.

https://github.com/grafana/redshift-datasource/blob/be82734ac176927387d7e5da71523a6191fcea73/src/plugin.json#L5

Fixes: #244