### PR TITLE
Do not call ListStatements in GetQueryID

### DIFF
--- a/pkg/redshift/api/api.go
+++ b/pkg/redshift/api/api.go
@@ -24,13 +24,6 @@ import (
 	"github.com/grafana/sqlds/v2"
 )
 
-var validStatuses = []string{
-	redshiftdataapiservice.StatementStatusStringSubmitted,
-	redshiftdataapiservice.StatementStatusStringPicked,
-	redshiftdataapiservice.StatementStatusStringStarted,
-	redshiftdataapiservice.StatementStatusStringFinished,
-}
-
 type API struct {
 	DataClient                 redshiftdataapiserviceiface.RedshiftDataAPIServiceAPI
 	SecretsClient              secretsmanageriface.SecretsManagerAPI

--- a/pkg/redshift/api/api.go
+++ b/pkg/redshift/api/api.go
@@ -123,45 +123,9 @@ func (c *API) Execute(ctx context.Context, input *api.ExecuteQueryInput) (*api.E
 	return &api.ExecuteQueryOutput{ID: *output.Id}, nil
 }
 
-func sliceContains(slice []string, str string) bool {
-	for _, val := range slice {
-		if val == str {
-			return true
-		}
-	}
-	return false
-}
-
+// GetQueryID always returns not found. To actually check if the query has been called requires calling ListStatements, which can lead to timeouts
+// when there are many statements to page through
 func (c *API) GetQueryID(ctx context.Context, query string, args ...interface{}) (bool, string, error) {
-	input := &redshiftdataapiservice.ListStatementsInput{
-		Status: aws.String("ALL"),
-	}
-
-	output, err := c.DataClient.ListStatementsWithContext(ctx, input)
-	if err != nil {
-		return false, "", fmt.Errorf("%w: %v", api.ExecuteError, err)
-	}
-
-	for {
-		for _, statement := range output.Statements {
-			if statement.QueryString != nil && *statement.QueryString == query {
-				if statement.Status != nil && sliceContains(validStatuses, *statement.Status) {
-					return true, *statement.Id, nil
-				}
-				return false, "", nil
-			}
-		}
-
-		if output.NextToken == nil {
-			break
-		}
-		input.SetNextToken(*output.NextToken)
-		output, err = c.DataClient.ListStatementsWithContext(ctx, input)
-		if err != nil {
-			return false, "", fmt.Errorf("%w: %v", api.ExecuteError, err)
-		}
-	}
-
 	return false, "", nil
 }
 

--- a/pkg/redshift/api/api_test.go
+++ b/pkg/redshift/api/api_test.go
@@ -112,56 +112,6 @@ func Test_Execute(t *testing.T) {
 	}
 }
 
-func Test_QueryID(t *testing.T) {
-	tests := map[string]struct {
-		query  string
-		status string
-		found  bool
-	}{
-		"found": {
-			query:  "foo bar",
-			status: redshiftdataapiservice.StatusStringFinished,
-			found:  true,
-		},
-		"ignored": {
-			query:  "foo bar",
-			status: redshiftdataapiservice.StatusStringFailed,
-			found:  false,
-		},
-		"not found": {
-			query:  "baz",
-			status: redshiftdataapiservice.StatusStringStarted,
-			found:  false,
-		},
-	}
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			c := &API{
-				settings: &models.RedshiftDataSourceSettings{},
-				DataClient: &redshiftclientmock.MockRedshiftClient{
-					ListStatementsOutput: &redshiftdataapiservice.ListStatementsOutput{
-						Statements: []*redshiftdataapiservice.StatementData{{
-							Id:          aws.String("foo"),
-							Status:      aws.String(tt.status),
-							QueryString: aws.String("foo bar"),
-						}},
-					},
-				},
-			}
-			found, id, err := c.GetQueryID(context.TODO(), tt.query)
-			if err != nil {
-				t.Errorf("unexpected error %v", err)
-			}
-			if found != tt.found {
-				t.Errorf("expecting found to be %v but got %v", tt.found, found)
-			}
-			if found && id != "foo" {
-				t.Errorf("expected an id to be returned")
-			}
-		})
-	}
-}
-
 func Test_Status(t *testing.T) {
 	tests := []struct {
 		description string


### PR DESCRIPTION
This PR stops calling ListStatements in GetQueryID, which was meant to sort of cache async queries instead of calling them multiple times, but can lead to timeouts if there are a lot of statements. This just returns false every time, since it:

a) is not worse than the synchronous solution (if you started multiple identical sync queries they would not check)
b) in retrospect can be (and hopefully is) handled more gracefully in async query caching (where we can cache a queryID for a query using the existing grafana query caching solution)

(note: we're already returning false every time in the Athena datasource for throttling reasons, so we know this works and I probably should have extrapolated from that)

fixes #250 