### PR TITLE
Prepare v1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.13.1
+
+- Bump go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace from 0.37.0 to 0.44.0 by @dependabot in https://github.com/grafana/redshift-datasource/pull/257
+- Upgrade grafana-plugin-sdk-go; add underscore, debug to package resolutions by @fridgepoet in https://github.com/grafana/redshift-datasource/pull/265
+
+**Full Changelog**: https://github.com/grafana/redshift-datasource/compare/v1.13.0...v1.13.1
+
 ## 1.13.0
 
 - Migrate Query and config editors to new form styling under feature toggle [#255](https://github.com/grafana/redshift-datasource/pull/255)

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -86,6 +86,9 @@
     "codebases",
     "fillmode",
     "Collapsable",
-    "instancemgmt"
+    "instancemgmt",
+    "opentelemetry",
+    "httptrace",
+    "otelhttptrace"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-redshift-datasource",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "Use Amazon Redshift in Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
## What's Changed
* Bump go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace from 0.37.0 to 0.44.0 by @dependabot in https://github.com/grafana/redshift-datasource/pull/257
* Fix build, remove failing e2e test by @sarahzinger in https://github.com/grafana/redshift-datasource/pull/261
* Move feature requests should now all be issues by @sarahzinger in https://github.com/grafana/redshift-datasource/pull/260
* Upgrade grafana-plugin-sdk-go; add underscore, debug to package resolutions by @fridgepoet in https://github.com/grafana/redshift-datasource/pull/265

**Full Changelog**: https://github.com/grafana/redshift-datasource/compare/v1.13.0...v1.13.1