### PR TITLE
Update grafana/async-query-data and prepare v1.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.13.3
+
+- Upgrade @grafana/async-query-data from 0.1.10 to 0.1.11 https://github.com/grafana/redshift-datasource/pull/269
+
 ## 1.13.2
 
 - Update grafana/aws-sdk-go to 0.20.0 https://github.com/grafana/redshift-datasource/pull/268

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-redshift-datasource",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "description": "Use Amazon Redshift in Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
@@ -23,9 +23,9 @@
   "author": "Grafana Labs",
   "license": "Apache-2.0",
   "dependencies": {
-    "@grafana/async-query-data": "0.1.10",
-    "@grafana/experimental": "1.7.0",
     "@emotion/css": "^11.1.3",
+    "@grafana/async-query-data": "0.1.11",
+    "@grafana/experimental": "1.7.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "tslib": "2.5.3"
@@ -68,6 +68,7 @@
     "glob": "^10.2.7",
     "identity-obj-proxy": "3.0.0",
     "jest": "^29.5.0",
+    "jest-environment-jsdom": "^29.5.0",
     "prettier": "^2.8.7",
     "react": "17.0.2",
     "react-dom": "17.0.2",
@@ -83,8 +84,7 @@
     "typescript": "4.8.4",
     "webpack": "^5.86.0",
     "webpack-cli": "^5.1.4",
-    "webpack-livereload-plugin": "^3.0.2",
-    "jest-environment-jsdom": "^29.5.0"
+    "webpack-livereload-plugin": "^3.0.2"
   },
   "resolutions": {
     "@grafana/e2e-selectors": "10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1564,10 +1564,10 @@
   dependencies:
     tslib "^2.4.0"
 
-"@grafana/async-query-data@0.1.10":
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/@grafana/async-query-data/-/async-query-data-0.1.10.tgz#0ecf576b0c72d878bb89aee9d913e2605c485e7d"
-  integrity sha512-3BQFtYjhKqP0WDgHFKHUBGzH6BvTg7aAlSG8rSmQVVYq1N+y+22nPUMZ5LbN/tLrHFVxcOCBGQSEwgN5DnK/YA==
+"@grafana/async-query-data@0.1.11":
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/@grafana/async-query-data/-/async-query-data-0.1.11.tgz#9964e3ffb25328151d00b67b25a04a5c5c133dd6"
+  integrity sha512-RW2sthimO+0xZl1K6dLWs9F4idvOQ+m/GRgnhuo7LWNYUYkrxlLsFZ6Yz9aRFq1Rkf5HsV0/ldFWlQNmxuL9tQ==
   dependencies:
     tslib "^2.4.1"
 


### PR DESCRIPTION
Update redshift's grafana/async-query-data so we use distinct requestIds for different datasource instances, and prepare the release.

You can repro this on main by creating a dashboard with panels using 2 different redshift datasources. More often than not, one will be aborted (because of the identical requestIds). With the updated library, they will not be aborted.