### PR TITLE
Remove the redshiftAsyncQuerySupport feature toggle + styling improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.14.0
+
+- Remove the redshiftAsyncQuerySupport feature toggle + styling improvements in https://github.com/grafana/redshift-datasource/pull/272
+
 ## 1.13.3
 
 - Upgrade @grafana/async-query-data from 0.1.10 to 0.1.11 https://github.com/grafana/redshift-datasource/pull/269

--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Imported dashboards can be found in Configuration > Data Sources > select your R
 
 Async Query Data support enables an asynchronous query handling flow. With Async Query Data support enabled, queries will be handled over multiple requests (starting, checking its status, and fetching the results) instead of having a query be started and resolved over a single request. This is useful for queries that can potentially run for a long time and timeout. You'll need to ensure the IAM policy used by Grafana allows the following actions `redshift-data:ListStatements` and `redshift-data:CancelStatement`.
 
-Async query data support is enabled by default in all Athena datasources.
+Async query data support is enabled by default in all Redshift datasources.
 
 ### Async Query Caching
 

--- a/README.md
+++ b/README.md
@@ -260,9 +260,9 @@ Imported dashboards can be found in Configuration > Data Sources > select your R
 
 ## Async Query Data Support
 
-Async Query Data support enables an asynchronous query handling flow. With Async Query Data support enabled, queries will be handled over multiple requests (starting, checking its status, and fetching the results) instead of having a query be started and resolved over a single request. This is useful for queries that can potentially run for a long time and timeout.
+Async Query Data support enables an asynchronous query handling flow. With Async Query Data support enabled, queries will be handled over multiple requests (starting, checking its status, and fetching the results) instead of having a query be started and resolved over a single request. This is useful for queries that can potentially run for a long time and timeout. You'll need to ensure the IAM policy used by Grafana allows the following actions `redshift-data:ListStatements` and `redshift-data:CancelStatement`.
 
-To enable async query data support, you need to set feature toggle `redshiftAsyncQueryDataSupport` to `true`. Here are instructions to [configure feature toggles](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#feature_toggles). You'll also need to ensure the IAM policy used by Grafana allows the following actions `redshift-data:ListStatements` and `redshift-data:CancelStatement`.
+Async query data support is enabled by default in all Athena datasources.
 
 ### Async Query Caching
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-redshift-datasource",
-  "version": "1.13.3",
+  "version": "1.14.0",
   "description": "Use Amazon Redshift in Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
@@ -24,7 +24,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@emotion/css": "^11.1.3",
-    "@grafana/async-query-data": "0.1.11",
+    "@grafana/async-query-data": "0.2.0",
     "@grafana/experimental": "1.7.0",
     "react": "17.0.2",
     "react-dom": "17.0.2",

--- a/src/ConfigEditor/ConfigEditor.tsx
+++ b/src/ConfigEditor/ConfigEditor.tsx
@@ -1,5 +1,5 @@
 import { ConfigSelect, ConnectionConfig, InlineInput, Divider } from '@grafana/aws-sdk';
-import { DataSourcePluginOptionsEditorProps, SelectableValue } from '@grafana/data';
+import { DataSourcePluginOptionsEditorProps, SelectableValue, GrafanaTheme2 } from '@grafana/data';
 import { config, getBackendSrv } from '@grafana/runtime';
 import React, { FormEvent, useEffect, useState } from 'react';
 import { selectors } from 'selectors';
@@ -11,7 +11,8 @@ import {
   RedshiftManagedSecret,
 } from '../types';
 import { AuthTypeSwitch } from './AuthTypeSwitch';
-import { Field, InlineField, Input, Switch } from '@grafana/ui';
+import { Field, InlineField, Input, Switch, useStyles2 } from '@grafana/ui';
+import { css } from '@emotion/css';
 import { ConfigSection } from '@grafana/experimental';
 
 export type Props = DataSourcePluginOptionsEditorProps<RedshiftDataSourceOptions, RedshiftDataSourceSecureJsonData>;
@@ -44,6 +45,9 @@ export function ConfigEditor(props: Props) {
   const { jsonData } = props.options;
   const [saved, setSaved] = useState(!!jsonData.defaultRegion);
   const newFormStylingEnabled = config.featureToggles.awsDatasourcesNewFormStyling;
+
+  const styles = useStyles2(getStyles);
+
   const saveOptions = async () => {
     if (saved) {
       return;
@@ -237,7 +241,7 @@ export function ConfigEditor(props: Props) {
   };
 
   return (
-    <div className="width-30">
+    <div className={styles.formStyles}>
       <ConnectionConfig {...props} onOptionsChange={onOptionsChange} newFormStylingEnabled={newFormStylingEnabled} />
       {newFormStylingEnabled ? (
         <>
@@ -491,3 +495,9 @@ export function ConfigEditor(props: Props) {
     </div>
   );
 }
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  formStyles: css({
+    maxWidth: theme.spacing(50),
+  }),
+});

--- a/src/QueryEditor.test.tsx
+++ b/src/QueryEditor.test.tsx
@@ -24,14 +24,6 @@ const props = {
   onChange: jest.fn(),
   onRunQuery: jest.fn(),
 };
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual<typeof runtime>('@grafana/runtime'),
-  config: {
-    featureToggles: {
-      redshiftAsyncQueryDataSupport: true,
-    },
-  },
-}));
 
 beforeEach(() => {
   ds.getResource = jest.fn().mockResolvedValue([]);
@@ -44,28 +36,9 @@ describe('Query Editor', () => {
     const runButton = screen.getByRole('button', { name: 'Run query' });
     expect(runButton).toBeDisabled();
   });
-  it('should show cancel button if redshiftAsyncQueryDataSupport feature is enabled', () => {
+  it('should show cancel button', () => {
     render(<QueryEditor {...props} />);
     const cancelButton = screen.getByRole('button', { name: 'Stop query' });
     expect(cancelButton).toBeInTheDocument();
-  });
-  it('should not show cancel button if redshiftAsyncQueryDataSupport feature is disabled', () => {
-    config.featureToggles.redshiftAsyncQueryDataSupport = false;
-    render(<QueryEditor {...props} />);
-    const cancelButton = screen.queryByRole('button', { name: 'Stop query' });
-    expect(cancelButton).not.toBeInTheDocument();
-  });
-  it('should re-enable Run query button if there is a change to the query', async () => {
-    render(<QueryEditor {...props} query={{ ...props.query, rawSQL: 'initial query' }} />);
-    const runButton = screen.getByRole('button', { name: 'Run query' });
-    expect(runButton).toBeDisabled();
-
-    const input = screen.getByTestId('codeEditor');
-    expect(input).toBeDefined();
-
-    fireEvent.change(input, { target: { value: 'test query' } });
-
-    expect(props.onChange).toHaveBeenCalledWith({ ...props.query, rawSQL: 'test query' });
-    expect(runButton).not.toBeDisabled();
   });
 });

--- a/src/QueryEditor.test.tsx
+++ b/src/QueryEditor.test.tsx
@@ -1,10 +1,8 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { QueryEditor } from 'QueryEditor';
 import React from 'react';
 import { mockDatasource, mockQuery } from './__mocks__/datasource';
 import * as experimental from '@grafana/experimental';
-import * as runtime from '@grafana/runtime';
-import { config } from '@grafana/runtime';
 
 const ds = mockDatasource;
 const q = { ...mockQuery, rawSQL: '' };

--- a/src/QueryEditor.tsx
+++ b/src/QueryEditor.tsx
@@ -1,5 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { config } from '@grafana/runtime';
+import React from 'react';
 import { QueryEditorProps } from '@grafana/data';
 import { QueryEditorHeader } from '@grafana/aws-sdk';
 import { RedshiftDataSourceOptions, RedshiftQuery } from './types';
@@ -7,32 +6,17 @@ import { DataSource } from './datasource';
 import { QueryEditorForm } from './QueryEditorForm';
 
 export function QueryEditor(props: QueryEditorProps<DataSource, RedshiftQuery, RedshiftDataSourceOptions>) {
-  const [dataIsStale, setDataIsStale] = useState(false);
-  const { onChange } = props;
-
-  useEffect(() => {
-    setDataIsStale(false);
-  }, [props.data]);
-
-  const onChangeInternal = useCallback(
-    (query: RedshiftQuery) => {
-      setDataIsStale(true);
-      onChange(query);
-    },
-    [onChange]
-  );
-
   return (
     <>
       {props?.app !== 'explore' && (
         <QueryEditorHeader<DataSource, RedshiftQuery, RedshiftDataSourceOptions>
           {...props}
-          enableRunButton={dataIsStale && !!props.query.rawSQL}
-          showAsyncQueryButtons={config.featureToggles.redshiftAsyncQueryDataSupport}
-          cancel={config.featureToggles.redshiftAsyncQueryDataSupport ? props.datasource.cancel : undefined}
+          enableRunButton={!!props.query.rawSQL}
+          showAsyncQueryButtons
+          cancel={props.datasource.cancel}
         />
       )}
-      <QueryEditorForm {...props} onChange={onChangeInternal} />
+      <QueryEditorForm {...props} />
     </>
   );
 }

--- a/src/QueryEditorForm.test.tsx
+++ b/src/QueryEditorForm.test.tsx
@@ -25,7 +25,6 @@ jest.mock('@grafana/runtime', () => ({
   config: {
     featureToggles: {
       awsDatasourcesNewFormStyling: false,
-      redshiftAsyncQueryDataSupport: true,
     },
   },
 }));

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -9,7 +9,7 @@ import { RedshiftAnnotationsSupport } from './annotations';
 
 export class DataSource extends DatasourceWithAsyncBackend<RedshiftQuery, RedshiftDataSourceOptions> {
   constructor(instanceSettings: DataSourceInstanceSettings<RedshiftDataSourceOptions>) {
-    super(instanceSettings, config.featureToggles.redshiftAsyncQueryDataSupport);
+    super(instanceSettings);
     this.variables = new RedshiftVariableSupport(this);
   }
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -1,7 +1,7 @@
 import { applySQLTemplateVariables, filterSQLQuery } from '@grafana/aws-sdk';
 import { DatasourceWithAsyncBackend } from '@grafana/async-query-data';
 import { DataSourceInstanceSettings, ScopedVars } from '@grafana/data';
-import { getTemplateSrv, config } from '@grafana/runtime';
+import { getTemplateSrv } from '@grafana/runtime';
 import { RedshiftVariableSupport } from 'variables';
 
 import { RedshiftDataSourceOptions, RedshiftQuery } from './types';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1564,17 +1564,17 @@
   dependencies:
     tslib "^2.4.0"
 
-"@grafana/async-query-data@0.1.11":
-  version "0.1.11"
-  resolved "https://registry.yarnpkg.com/@grafana/async-query-data/-/async-query-data-0.1.11.tgz#9964e3ffb25328151d00b67b25a04a5c5c133dd6"
-  integrity sha512-RW2sthimO+0xZl1K6dLWs9F4idvOQ+m/GRgnhuo7LWNYUYkrxlLsFZ6Yz9aRFq1Rkf5HsV0/ldFWlQNmxuL9tQ==
-  dependencies:
-    tslib "^2.4.1"
-
 "@grafana/async-query-data@0.1.4":
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/@grafana/async-query-data/-/async-query-data-0.1.4.tgz#ac24e32822a8032dd1ee10ce7dcb8c2e276c58b0"
   integrity sha512-3d7fm2sf5x/+JKTt4T6MSS/veB2J/YGfQp5Ck0Tbqtc5YIoI0p1JY+vFWfCstEHyVd1H0Ep/q/VSxf4VAs9YKQ==
+  dependencies:
+    tslib "^2.4.1"
+
+"@grafana/async-query-data@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@grafana/async-query-data/-/async-query-data-0.2.0.tgz#2df8a69da527ce1993fc74a6bce452582fb76649"
+  integrity sha512-CduRkX8Bl8/+uiDTrKXjPN2h3kjVE67VgeZAZlVKcjCsxDlDpbVYXMVbfTJBGr4HqzDHg1Km6UkmeuOAt2bBww==
   dependencies:
     tslib "^2.4.1"
 


### PR DESCRIPTION
Same as https://github.com/grafana/athena-datasource/pull/316

Did a few things here: 
- remove the redshiftAsyncQuerySupport feature toggle
- removed the use of deprecated width-30 class to instead use Grafana theme spacing
- fixed the Run query button to not be disabled if there is no change in the editor. I was kinda bothered by this cause I sometimes just wanted to rerun the same query and not have to go all the way up to the Grafana dashboard refresh button. Also I realized this is how Cloudwatch header buttons work - the Run button is never disabled

I thought the changes were small enough to squeeze in here, but lmk if you'd rather I separate them into 2 or 3 PRs.