### PR TITLE
Plugin.json: update schema reference URL

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/grafana/grafana/master/docs/sources/developers/plugins/plugin.schema.json",
+  "$schema": "https://raw.githubusercontent.com/grafana/grafana/main/docs/sources/developers/plugins/plugin.schema.json",
   "type": "datasource",
   "name": "Amazon Redshift",
   "id": "grafana-redshift-datasource",


### PR DESCRIPTION
### What changed?

Updated the reference to the plugin.json schema (it was pointing to the old one).