### PR TITLE
Fix E2E: Update region before sending the /secrets resource request

### DIFF
--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -55,11 +55,11 @@ e2e.scenario({
               .type(datasource.jsonData.defaultRegion)
               .type('{enter}');
             e2e().get('label').contains('AWS Secrets Manager').click({ force: true });
-            cy.wait(2000);
+            cy.wait(5000);
             e2eSelectors.ConfigEditor.ManagedSecret.input().click({ force: true });
             e2eSelectors.ConfigEditor.ManagedSecret.input().type(datasource.jsonData.managedSecret.name);
             // wait for it to load
-            e2eSelectors.ConfigEditor.ManagedSecret.testID().contains(datasource.jsonData.managedSecret.name, {timeout: 10000});
+            e2eSelectors.ConfigEditor.ManagedSecret.testID().contains(datasource.jsonData.managedSecret.name);
             e2eSelectors.ConfigEditor.ManagedSecret.input().type('{enter}');
             // wait for the secret to be retrieved
             e2eSelectors.ConfigEditor.ClusterIDText.testID().should(

--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -58,7 +58,7 @@ e2e.scenario({
             e2eSelectors.ConfigEditor.ManagedSecret.input().click({ force: true });
             e2eSelectors.ConfigEditor.ManagedSecret.input().type(datasource.jsonData.managedSecret.name);
             // wait for it to load
-            e2eSelectors.ConfigEditor.ManagedSecret.testID().contains(datasource.jsonData.managedSecret.name);
+            e2eSelectors.ConfigEditor.ManagedSecret.testID().contains(datasource.jsonData.managedSecret.name, {timeout: 10000});
             e2eSelectors.ConfigEditor.ManagedSecret.input().type('{enter}');
             // wait for the secret to be retrieved
             e2eSelectors.ConfigEditor.ClusterIDText.testID().should(

--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -55,6 +55,7 @@ e2e.scenario({
               .type(datasource.jsonData.defaultRegion)
               .type('{enter}');
             e2e().get('label').contains('AWS Secrets Manager').click({ force: true });
+            cy.wait(5000);
             e2eSelectors.ConfigEditor.ManagedSecret.input().click({ force: true });
             e2eSelectors.ConfigEditor.ManagedSecret.input().type(datasource.jsonData.managedSecret.name);
             // wait for it to load

--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -55,6 +55,7 @@ e2e.scenario({
               .type(datasource.jsonData.defaultRegion)
               .type('{enter}');
             e2e().get('label').contains('AWS Secrets Manager').click({ force: true });
+            // wait for the region to update before selecting the ManagedSecret input (which will send a request that requires the region)
             cy.wait(5000);
             e2eSelectors.ConfigEditor.ManagedSecret.input().click({ force: true });
             e2eSelectors.ConfigEditor.ManagedSecret.input().type(datasource.jsonData.managedSecret.name);

--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -55,7 +55,7 @@ e2e.scenario({
               .type(datasource.jsonData.defaultRegion)
               .type('{enter}');
             e2e().get('label').contains('AWS Secrets Manager').click({ force: true });
-            cy.wait(5000);
+            cy.wait(2000);
             e2eSelectors.ConfigEditor.ManagedSecret.input().click({ force: true });
             e2eSelectors.ConfigEditor.ManagedSecret.input().type(datasource.jsonData.managedSecret.name);
             // wait for it to load


### PR DESCRIPTION
We were getting "Missing region" error on /secrets resource request. It looks like the delay between selecting a region and sending a the /secrets request in the test (by clicking on the `Managed secret` input) is too short. Adding a `cy.wait(5000)` seems to fix it.  
<img width="974" alt="Screenshot 2024-05-29 at 19 00 52" src="https://github.com/grafana/redshift-datasource/assets/16140639/331f437b-c87f-4be6-8bb1-5e57bc1bf48a">

Tried decreasing it to 2000 ms but looks like that's still too short. 
It's probably not the best or foolproof solution, but we will be migrating eventually to plugin-e2e