### PR TITLE
Docs: Update template variable docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ To add a new Redshift query variable, refer to [Add a query variable](https://gr
 
 Any value queried from a Redshift table can be used as a variable. Be sure to avoid selecting too many values, as this can cause performance issues.
 
+To display a custom display name for a variable, you can use a query such as `SELECT hostname AS text, id AS value FROM MyTable`. In this case the variable value field must be a string type or cast to a string type. 
+
 After creating a variable, you can use it in your Redshift queries by using [Variable syntax](https://grafana.com/docs/grafana/latest/variables/syntax/). For more information about variables, refer to [Templates and variables](https://grafana.com/docs/grafana/latest/variables/).
 
 ### Annotations


### PR DESCRIPTION
Same as the equivalent PR in Athena: https://github.com/grafana/athena-datasource/pull/336

An [issue](https://github.com/grafana/athena-datasource/issues/286) reported adding variables with custom display values doesn't work in Athena or Redshift: 
`SELECT 'foo' AS __text, 'bar' AS __value`

In reality, this isn't a bug but a series of unfortunate events.
1. Grafana docs were misleading and `text` and `value` should be used instead (fixed [here](https://github.com/grafana/grafana/pull/88824))
2. The values must be a field type string. We could add custom logic for both datasources to parse other field types to string; however some other datasources (bigquery and yugabyte) have opted to not do so and defer to the generic Grafana variable code. This means the users are responsible for writing queries that return a string as value. This update in docs reflects that. 