### PR TITLE
Migrate to new form styling in config and query editors

### DIFF
--- a/cypress/integration/smoke.spec.ts
+++ b/cypress/integration/smoke.spec.ts
@@ -48,12 +48,15 @@ e2e.scenario({
           expectedAlertMessage: 'Data source is working',
           form: () => {
             e2eSelectors.ConfigEditor.AuthenticationProvider.input().type('Access & secret key').type('{enter}');
-            e2eSelectors.ConfigEditor.AccessKey.input().type(datasource.secureJsonData.accessKey);
-            e2eSelectors.ConfigEditor.SecretKey.input().type(datasource.secureJsonData.secretKey);
-            e2eSelectors.ConfigEditor.DefaultRegion.input()
+            cy.contains('label', selectors.components.ConfigEditor.AccessKey.input).type(
+              datasource.secureJsonData.accessKey
+            );
+            cy.contains('label', selectors.components.ConfigEditor.SecretKey.input).type(
+              datasource.secureJsonData.secretKey
+            );
+            cy.contains('label', selectors.components.ConfigEditor.DefaultRegion.input)
               .click({ force: true })
-              .type(datasource.jsonData.defaultRegion)
-              .type('{enter}');
+              .type(`${datasource.jsonData.defaultRegion}{enter}`);
             e2e().get('label').contains('AWS Secrets Manager').click({ force: true });
             // wait for the region to update before selecting the ManagedSecret input (which will send a request that requires the region)
             cy.wait(5000);

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@babel/core": "^7.21.4",
     "@emotion/css": "^11.1.3",
-    "@grafana/aws-sdk": "0.3.1",
+    "@grafana/aws-sdk": "0.4.0",
     "@grafana/data": "10.2.0",
     "@grafana/e2e": "10.2.0",
     "@grafana/e2e-selectors": "10.0.0",

--- a/src/ConfigEditor/ConfigEditor.test.tsx
+++ b/src/ConfigEditor/ConfigEditor.test.tsx
@@ -5,7 +5,6 @@ import { select } from 'react-select-event';
 import { mockDatasourceOptions } from '../__mocks__/datasource';
 import { selectors } from '../selectors';
 import { ConfigEditor } from './ConfigEditor';
-import { config } from '@grafana/runtime';
 
 const clusterIdentifier = 'cluster';
 const workgroupName = 'workgroup';
@@ -16,11 +15,6 @@ const provisionedSecretFetched = { dbClusterIdentifier: clusterIdentifier, usern
 const serverlessSecretFetched = { dbClusterIdentifier: '', username: dbUser };
 const cluster = { clusterIdentifier, endpoint: { address: 'bar.d.e.f', port: 456 }, database: 'db2' };
 const workgroup = { workgroupName, endpoint: { address: 'foo.a.b.c', port: 123 }, database: 'db1' };
-const originalFormFeatureToggleValue = config.featureToggles.awsDatasourcesNewFormStyling;
-
-const cleanupFeatureToggle = () => {
-  config.featureToggles.awsDatasourcesNewFormStyling = originalFormFeatureToggleValue;
-};
 
 jest.mock('@grafana/aws-sdk', () => {
   return {
@@ -57,323 +51,297 @@ jest.mock('@grafana/runtime', () => {
         }
       }),
     }),
-    config: {
-      featureToggles: {
-        awsDatasourcesNewFormStyling: false,
-      },
-    },
   };
 });
 
 const props = mockDatasourceOptions;
 
 describe('ConfigEditor', () => {
-  function run() {
-    it('should display Provisioned using Secrets Manager', () => {
-      render(<ConfigEditor {...props} />);
-      expect(screen.getByTestId(selectors.components.ConfigEditor.WorkgroupText.testID)).not.toBeVisible();
-      expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterID.testID)).not.toBeVisible();
-      expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterIDText.testID)).toBeVisible();
-      expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterIDText.testID)).toBeDisabled();
-      expect(screen.getByText(selectors.components.ConfigEditor.ManagedSecret.input)).toBeVisible();
-      expect(screen.getByText(selectors.components.ConfigEditor.DatabaseUser.input)).toBeVisible();
-      expect(screen.getByText(selectors.components.ConfigEditor.Database.input)).not.toBeDisabled();
-    });
+  it('should display Provisioned using Secrets Manager', () => {
+    render(<ConfigEditor {...props} />);
+    expect(screen.getByTestId(selectors.components.ConfigEditor.WorkgroupText.testID)).not.toBeVisible();
+    expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterID.testID)).not.toBeVisible();
+    expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterIDText.testID)).toBeVisible();
+    expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterIDText.testID)).toBeDisabled();
+    expect(screen.getByText(selectors.components.ConfigEditor.ManagedSecret.input)).toBeVisible();
+    expect(screen.getByText(selectors.components.ConfigEditor.DatabaseUser.input)).toBeVisible();
+    expect(screen.getByText(selectors.components.ConfigEditor.Database.input)).not.toBeDisabled();
+  });
 
-    it('should display Provisioned using Temporary credentials', () => {
-      render(<ConfigEditor {...props} />);
-      screen.getByText('Temporary credentials').click();
-      expect(screen.getByTestId(selectors.components.ConfigEditor.WorkgroupText.testID)).not.toBeVisible();
-      expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterID.testID)).toBeVisible();
-      expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterIDText.testID)).not.toBeVisible();
-      expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterIDText.testID)).toBeDisabled();
-      expect(screen.getByText(selectors.components.ConfigEditor.ManagedSecret.input)).not.toBeVisible();
-      expect(screen.getByText(selectors.components.ConfigEditor.DatabaseUser.input)).toBeVisible();
-      expect(screen.getByText(selectors.components.ConfigEditor.DatabaseUser.input)).not.toBeDisabled();
-      expect(screen.getByText(selectors.components.ConfigEditor.Database.input)).not.toBeDisabled();
-    });
+  it('should display Provisioned using Temporary credentials', () => {
+    render(<ConfigEditor {...props} />);
+    screen.getByText('Temporary credentials').click();
+    expect(screen.getByTestId(selectors.components.ConfigEditor.WorkgroupText.testID)).not.toBeVisible();
+    expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterID.testID)).toBeVisible();
+    expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterIDText.testID)).not.toBeVisible();
+    expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterIDText.testID)).toBeDisabled();
+    expect(screen.getByText(selectors.components.ConfigEditor.ManagedSecret.input)).not.toBeVisible();
+    expect(screen.getByText(selectors.components.ConfigEditor.DatabaseUser.input)).toBeVisible();
+    expect(screen.getByText(selectors.components.ConfigEditor.DatabaseUser.input)).not.toBeDisabled();
+    expect(screen.getByText(selectors.components.ConfigEditor.Database.input)).not.toBeDisabled();
+  });
 
-    it('should display Serverless using Secrets Manager', () => {
-      render(
-        <ConfigEditor
-          {...{
-            ...props,
-            options: {
-              ...props.options,
-              jsonData: {
-                ...props.options.jsonData,
-                useServerless: true,
-              },
-            },
-          }}
-        />
-      );
-      expect(screen.getByTestId(selectors.components.ConfigEditor.WorkgroupText.testID)).toBeVisible();
-      expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterID.testID)).not.toBeVisible();
-      expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterIDText.testID)).not.toBeVisible();
-      expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterIDText.testID)).toBeDisabled();
-      expect(screen.getByText(selectors.components.ConfigEditor.ManagedSecret.input)).toBeVisible();
-      expect(screen.getByText(selectors.components.ConfigEditor.DatabaseUser.input)).toBeVisible();
-      expect(screen.getByText(selectors.components.ConfigEditor.Database.input)).not.toBeDisabled();
-    });
-
-    it('should display Serverless using Temporary credentials', () => {
-      render(
-        <ConfigEditor
-          {...{
-            ...props,
-            options: {
-              ...props.options,
-              jsonData: {
-                ...props.options.jsonData,
-                useServerless: true,
-              },
-            },
-          }}
-        />
-      );
-      screen.getByText('Temporary credentials').click();
-      expect(screen.getByTestId(selectors.components.ConfigEditor.WorkgroupText.testID)).toBeVisible();
-      expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterID.testID)).not.toBeVisible();
-      expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterIDText.testID)).not.toBeVisible();
-      expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterIDText.testID)).toBeDisabled();
-      expect(screen.getByText(selectors.components.ConfigEditor.ManagedSecret.input)).not.toBeVisible();
-      expect(screen.getByText(selectors.components.ConfigEditor.DatabaseUser.input)).not.toBeVisible();
-      expect(screen.getByText(selectors.components.ConfigEditor.Database.input)).not.toBeDisabled();
-    });
-
-    it('should select a secret', async () => {
-      const onChange = jest.fn();
-      render(<ConfigEditor {...props} onOptionsChange={onChange} />);
-
-      screen.getByText('AWS Secrets Manager').click();
-
-      const selectEl = screen.getByLabelText(selectors.components.ConfigEditor.ManagedSecret.input);
-      expect(selectEl).toBeInTheDocument();
-      await select(selectEl, provisionedSecret.arn, { container: document.body });
-
-      expect(onChange).toHaveBeenCalledWith({
-        ...props.options,
-        jsonData: { ...props.options.jsonData, managedSecret: provisionedSecret },
-      });
-    });
-
-    it('should allow user to enter a database', async () => {
-      const onChange = jest.fn();
-      render(<ConfigEditor {...props} onOptionsChange={onChange} />);
-
-      const dbField = screen.getByTestId('data-testid database');
-      expect(dbField).toBeInTheDocument();
-      fireEvent.change(dbField, { target: { value: 'abcd' } });
-
-      expect(onChange).toHaveBeenCalledTimes(1);
-      expect(onChange).toHaveBeenCalledWith({
-        ...props.options,
-        url: '/abcd',
-        jsonData: { ...props.options.jsonData, database: 'abcd' },
-      });
-    });
-
-    it('should enable WithEvent when it is toggled on', async () => {
-      const onChange = jest.fn();
-      render(<ConfigEditor {...props} onOptionsChange={onChange} />);
-      const withEventField = screen.getByTestId(selectors.components.ConfigEditor.WithEvent.testID);
-      expect(withEventField).toBeInTheDocument();
-
-      fireEvent.click(withEventField);
-
-      expect(onChange).toHaveBeenCalledTimes(1);
-      expect(onChange).toHaveBeenCalledWith({
-        ...props.options,
-        jsonData: { ...props.options.jsonData, withEvent: true },
-      });
-    });
-
-    it('should populate the `url` prop when workGroupName is selected', async () => {
-      const onChange = jest.fn();
-      render(
-        <ConfigEditor
-          {...props}
-          options={{
-            ...props.options,
-            jsonData: { ...props.options.jsonData, database: 'test-db' },
-          }}
-          onOptionsChange={onChange}
-        />
-      );
-
-      const selectEl = screen.getByLabelText(selectors.components.ConfigEditor.WorkgroupText.input);
-      expect(selectEl).toBeInTheDocument();
-      await select(selectEl, workgroup.workgroupName, { container: document.body });
-
-      await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
-      expect(onChange).toHaveBeenCalledWith({
-        ...props.options,
-        url: 'foo.a.b.c:123/test-db',
-        jsonData: { ...props.options.jsonData, database: 'test-db', workgroupName },
-      });
-    });
-
-    it('should populate the `url` prop when clusterIdentifier is selected', async () => {
-      const onChange = jest.fn();
-      render(
-        <ConfigEditor
-          {...props}
-          options={{
-            ...props.options,
-            jsonData: { ...props.options.jsonData, database: 'test-db', useManagedSecret: false },
-          }}
-          onOptionsChange={onChange}
-        />
-      );
-
-      const selectEl = screen.getByRole('combobox', { name: selectors.components.ConfigEditor.ClusterID.input });
-      expect(selectEl).toBeInTheDocument();
-      await select(selectEl, cluster.clusterIdentifier, { container: document.body });
-
-      await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
-      expect(onChange).toHaveBeenCalledWith({
-        ...props.options,
-        url: 'bar.d.e.f:456/test-db',
-        jsonData: {
-          ...props.options.jsonData,
-          database: 'test-db',
-          clusterIdentifier: clusterIdentifier,
-          useManagedSecret: false,
-        },
-      });
-    });
-
-    it('should update an existing url when specifying a database', async () => {
-      const onChange = jest.fn();
-      await act(async () => {
-        render(
-          <ConfigEditor
-            {...props}
-            onOptionsChange={onChange}
-            options={{
-              ...props.options,
-              url: 'my.cluster.address:123/my-old-db',
-              jsonData: {
-                ...props.options.jsonData,
-                clusterIdentifier,
-                useServerless: false,
-                useManagedSecret: false,
-              },
-            }}
-          />
-        );
-      });
-
-      const dbField = screen.getByTestId('data-testid database');
-      expect(dbField).toBeInTheDocument();
-      fireEvent.change(dbField, { target: { value: 'abcd' } });
-
-      expect(onChange).toHaveBeenCalledTimes(1);
-      expect(onChange).toHaveBeenCalledWith({
-        ...props.options,
-        // the endpoint is updated as re-fetched
-        url: 'bar.d.e.f:456/abcd',
-        jsonData: {
-          ...props.options.jsonData,
-          clusterIdentifier,
-          useServerless: false,
-          useManagedSecret: false,
-          database: 'abcd',
-        },
-      });
-    });
-
-    it('should show the cluster identifier and the db user', async () => {
-      const onChange = jest.fn();
-      render(
-        <ConfigEditor
-          {...props}
-          onOptionsChange={onChange}
-          // setting the managedSecret will trigger the secret retrieval
-          options={{
-            ...props.options,
-            jsonData: {
-              ...props.options.jsonData,
-              useServerless: false,
-              useManagedSecret: true,
-              managedSecret: provisionedSecret,
-            },
-          }}
-        />
-      );
-
-      // the clusterIdentifier and dbUser update is delegated to the onChange function
-      await waitFor(() =>
-        expect(onChange).toHaveBeenCalledWith({
-          ...props.options,
-          url: 'bar.d.e.f:456/',
-          jsonData: {
-            ...props.options.jsonData,
-            dbUser,
-            useServerless: false,
-            useManagedSecret: true,
-            managedSecret: provisionedSecret,
-            clusterIdentifier,
-          },
-        })
-      );
-    });
-
-    it('should show the dbUser', async () => {
-      const onChange = jest.fn();
-      render(
-        <ConfigEditor
-          {...props}
-          onOptionsChange={onChange}
-          // setting the managedSecret will trigger the secret retrieval
-          options={{
+  it('should display Serverless using Secrets Manager', () => {
+    render(
+      <ConfigEditor
+        {...{
+          ...props,
+          options: {
             ...props.options,
             jsonData: {
               ...props.options.jsonData,
               useServerless: true,
-              useManagedSecret: true,
-              managedSecret: serverlessSecret,
-              workgroupName,
+            },
+          },
+        }}
+      />
+    );
+    expect(screen.getByTestId(selectors.components.ConfigEditor.WorkgroupText.testID)).toBeVisible();
+    expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterID.testID)).not.toBeVisible();
+    expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterIDText.testID)).not.toBeVisible();
+    expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterIDText.testID)).toBeDisabled();
+    expect(screen.getByText(selectors.components.ConfigEditor.ManagedSecret.input)).toBeVisible();
+    expect(screen.getByText(selectors.components.ConfigEditor.DatabaseUser.input)).toBeVisible();
+    expect(screen.getByText(selectors.components.ConfigEditor.Database.input)).not.toBeDisabled();
+  });
+
+  it('should display Serverless using Temporary credentials', () => {
+    render(
+      <ConfigEditor
+        {...{
+          ...props,
+          options: {
+            ...props.options,
+            jsonData: {
+              ...props.options.jsonData,
+              useServerless: true,
+            },
+          },
+        }}
+      />
+    );
+    screen.getByText('Temporary credentials').click();
+    expect(screen.getByTestId(selectors.components.ConfigEditor.WorkgroupText.testID)).toBeVisible();
+    expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterID.testID)).not.toBeVisible();
+    expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterIDText.testID)).not.toBeVisible();
+    expect(screen.getByTestId(selectors.components.ConfigEditor.ClusterIDText.testID)).toBeDisabled();
+    expect(screen.getByText(selectors.components.ConfigEditor.ManagedSecret.input)).not.toBeVisible();
+    expect(screen.getByText(selectors.components.ConfigEditor.DatabaseUser.input)).not.toBeVisible();
+    expect(screen.getByText(selectors.components.ConfigEditor.Database.input)).not.toBeDisabled();
+  });
+
+  it('should select a secret', async () => {
+    const onChange = jest.fn();
+    render(<ConfigEditor {...props} onOptionsChange={onChange} />);
+
+    screen.getByText('AWS Secrets Manager').click();
+
+    const selectEl = screen.getByLabelText(selectors.components.ConfigEditor.ManagedSecret.input);
+    expect(selectEl).toBeInTheDocument();
+    await select(selectEl, provisionedSecret.arn, { container: document.body });
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...props.options,
+      jsonData: { ...props.options.jsonData, managedSecret: provisionedSecret },
+    });
+  });
+
+  it('should allow user to enter a database', async () => {
+    const onChange = jest.fn();
+    render(<ConfigEditor {...props} onOptionsChange={onChange} />);
+
+    const dbField = screen.getByTestId('data-testid database');
+    expect(dbField).toBeInTheDocument();
+    fireEvent.change(dbField, { target: { value: 'abcd' } });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith({
+      ...props.options,
+      url: '/abcd',
+      jsonData: { ...props.options.jsonData, database: 'abcd' },
+    });
+  });
+
+  it('should enable WithEvent when it is toggled on', async () => {
+    const onChange = jest.fn();
+    render(<ConfigEditor {...props} onOptionsChange={onChange} />);
+    const withEventField = screen.getByTestId(selectors.components.ConfigEditor.WithEvent.testID);
+    expect(withEventField).toBeInTheDocument();
+
+    fireEvent.click(withEventField);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith({
+      ...props.options,
+      jsonData: { ...props.options.jsonData, withEvent: true },
+    });
+  });
+
+  it('should populate the `url` prop when workGroupName is selected', async () => {
+    const onChange = jest.fn();
+    render(
+      <ConfigEditor
+        {...props}
+        options={{
+          ...props.options,
+          jsonData: { ...props.options.jsonData, database: 'test-db' },
+        }}
+        onOptionsChange={onChange}
+      />
+    );
+
+    const selectEl = screen.getByLabelText(selectors.components.ConfigEditor.WorkgroupText.input);
+    expect(selectEl).toBeInTheDocument();
+    await select(selectEl, workgroup.workgroupName, { container: document.body });
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+    expect(onChange).toHaveBeenCalledWith({
+      ...props.options,
+      url: 'foo.a.b.c:123/test-db',
+      jsonData: { ...props.options.jsonData, database: 'test-db', workgroupName },
+    });
+  });
+
+  it('should populate the `url` prop when clusterIdentifier is selected', async () => {
+    const onChange = jest.fn();
+    render(
+      <ConfigEditor
+        {...props}
+        options={{
+          ...props.options,
+          jsonData: { ...props.options.jsonData, database: 'test-db', useManagedSecret: false },
+        }}
+        onOptionsChange={onChange}
+      />
+    );
+
+    const selectEl = screen.getByRole('combobox', { name: selectors.components.ConfigEditor.ClusterID.input });
+    expect(selectEl).toBeInTheDocument();
+    await select(selectEl, cluster.clusterIdentifier, { container: document.body });
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+    expect(onChange).toHaveBeenCalledWith({
+      ...props.options,
+      url: 'bar.d.e.f:456/test-db',
+      jsonData: {
+        ...props.options.jsonData,
+        database: 'test-db',
+        clusterIdentifier: clusterIdentifier,
+        useManagedSecret: false,
+      },
+    });
+  });
+
+  it('should update an existing url when specifying a database', async () => {
+    const onChange = jest.fn();
+    await act(async () => {
+      render(
+        <ConfigEditor
+          {...props}
+          onOptionsChange={onChange}
+          options={{
+            ...props.options,
+            url: 'my.cluster.address:123/my-old-db',
+            jsonData: {
+              ...props.options.jsonData,
+              clusterIdentifier,
+              useServerless: false,
+              useManagedSecret: false,
             },
           }}
         />
       );
+    });
 
-      // the dbUser update is delegated to the onChange function
-      await waitFor(() =>
-        expect(onChange).toHaveBeenCalledWith({
+    const dbField = screen.getByTestId('data-testid database');
+    expect(dbField).toBeInTheDocument();
+    fireEvent.change(dbField, { target: { value: 'abcd' } });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith({
+      ...props.options,
+      // the endpoint is updated as re-fetched
+      url: 'bar.d.e.f:456/abcd',
+      jsonData: {
+        ...props.options.jsonData,
+        clusterIdentifier,
+        useServerless: false,
+        useManagedSecret: false,
+        database: 'abcd',
+      },
+    });
+  });
+
+  it('should show the cluster identifier and the db user', async () => {
+    const onChange = jest.fn();
+    render(
+      <ConfigEditor
+        {...props}
+        onOptionsChange={onChange}
+        // setting the managedSecret will trigger the secret retrieval
+        options={{
           ...props.options,
-          url: 'foo.a.b.c:123/',
           jsonData: {
             ...props.options.jsonData,
-            dbUser,
+            useServerless: false,
+            useManagedSecret: true,
+            managedSecret: provisionedSecret,
+          },
+        }}
+      />
+    );
+
+    // the clusterIdentifier and dbUser update is delegated to the onChange function
+    await waitFor(() =>
+      expect(onChange).toHaveBeenCalledWith({
+        ...props.options,
+        url: 'bar.d.e.f:456/',
+        jsonData: {
+          ...props.options.jsonData,
+          dbUser,
+          useServerless: false,
+          useManagedSecret: true,
+          managedSecret: provisionedSecret,
+          clusterIdentifier,
+        },
+      })
+    );
+  });
+
+  it('should show the dbUser', async () => {
+    const onChange = jest.fn();
+    render(
+      <ConfigEditor
+        {...props}
+        onOptionsChange={onChange}
+        // setting the managedSecret will trigger the secret retrieval
+        options={{
+          ...props.options,
+          jsonData: {
+            ...props.options.jsonData,
             useServerless: true,
             useManagedSecret: true,
             managedSecret: serverlessSecret,
             workgroupName,
           },
-        })
-      );
-    });
-  }
+        }}
+      />
+    );
 
-  describe('QueryEditorForm with awsDatasourcesNewFormStyling feature toggle disabled', () => {
-    beforeAll(() => {
-      config.featureToggles.awsDatasourcesNewFormStyling = false;
-    });
-    afterAll(() => {
-      cleanupFeatureToggle();
-    });
-    run();
-  });
-  describe('QueryEditorForm with awsDatasourcesNewFormStyling feature toggle enabled', () => {
-    beforeAll(() => {
-      config.featureToggles.awsDatasourcesNewFormStyling = true;
-    });
-    afterAll(() => {
-      cleanupFeatureToggle();
-    });
-    run();
+    // the dbUser update is delegated to the onChange function
+    await waitFor(() =>
+      expect(onChange).toHaveBeenCalledWith({
+        ...props.options,
+        url: 'foo.a.b.c:123/',
+        jsonData: {
+          ...props.options.jsonData,
+          dbUser,
+          useServerless: true,
+          useManagedSecret: true,
+          managedSecret: serverlessSecret,
+          workgroupName,
+        },
+      })
+    );
   });
 });

--- a/src/ConfigEditor/ConfigEditor.tsx
+++ b/src/ConfigEditor/ConfigEditor.tsx
@@ -1,6 +1,6 @@
-import { ConfigSelect, ConnectionConfig, InlineInput, Divider } from '@grafana/aws-sdk';
+import { ConfigSelect, ConnectionConfig, Divider } from '@grafana/aws-sdk';
 import { DataSourcePluginOptionsEditorProps, SelectableValue, GrafanaTheme2 } from '@grafana/data';
-import { config, getBackendSrv } from '@grafana/runtime';
+import { getBackendSrv } from '@grafana/runtime';
 import React, { FormEvent, useEffect, useState } from 'react';
 import { selectors } from 'selectors';
 
@@ -11,7 +11,7 @@ import {
   RedshiftManagedSecret,
 } from '../types';
 import { AuthTypeSwitch } from './AuthTypeSwitch';
-import { Field, InlineField, Input, Switch, useStyles2 } from '@grafana/ui';
+import { Field, Input, Switch, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { ConfigSection } from '@grafana/experimental';
 
@@ -44,7 +44,6 @@ export function ConfigEditor(props: Props) {
   const resourcesURL = `${baseURL}/resources`;
   const { jsonData } = props.options;
   const [saved, setSaved] = useState(!!jsonData.defaultRegion);
-  const newFormStylingEnabled = config.featureToggles.awsDatasourcesNewFormStyling;
 
   const styles = useStyles2(getStyles);
 
@@ -248,261 +247,141 @@ export function ConfigEditor(props: Props) {
 
   return (
     <div className={styles.formStyles}>
-      <ConnectionConfig
-        {...props}
-        onOptionsChange={onOptionsChange}
-        newFormStylingEnabled={newFormStylingEnabled}
-        loadRegions={fetchRegions}
-      />
-      {newFormStylingEnabled ? (
-        <>
-          <Divider />
-          <ConfigSection title="Redshift Details">
-            <AuthTypeSwitch
-              key="managedSecret"
-              useManagedSecret={useManagedSecret}
-              onChangeAuthType={onChangeAuthType}
-            />
-            <Field
-              label={selectors.components.ConfigEditor.UseServerless.input}
-              data-testid={selectors.components.ConfigEditor.UseServerless.testID}
-              htmlFor="useServerless"
-            >
-              <Switch
-                {...props}
-                id="useServerless"
-                value={props.options.jsonData.useServerless}
-                aria-label={selectors.components.ConfigEditor.UseServerless.input}
-                onChange={(e) =>
-                  props.onOptionsChange({
-                    ...props.options,
-                    jsonData: {
-                      ...props.options.jsonData,
-                      useServerless: e.currentTarget.checked,
-                    },
-                  })
-                }
-              />
-            </Field>
-            <Field
-              label={selectors.components.ConfigEditor.ClusterID.input}
-              data-testid={selectors.components.ConfigEditor.ClusterID.testID}
-              hidden={props.options.jsonData.useServerless || useManagedSecret}
-              htmlFor="clusterId"
-            >
-              <ConfigSelect
-                {...props}
-                id="clusterId"
-                label={selectors.components.ConfigEditor.ClusterID.input}
-                allowCustomValue={true}
-                value={props.options.jsonData.clusterIdentifier ?? ''}
-                onChange={onChangeClusterID}
-                fetch={fetchClusters}
-                saveOptions={saveOptions}
-                newFormStylingEnabled={true}
-              />
-            </Field>
-
-            <Field
-              hidden={props.options.jsonData.useServerless || !useManagedSecret}
-              label={selectors.components.ConfigEditor.ClusterIDText.input}
-              disabled={true}
-              htmlFor="clusterIdText"
-            >
-              <Input
-                {...props}
-                id="clusterIdText"
-                value={props.options.jsonData.clusterIdentifier ?? ''}
-                onChange={() => {}}
-                label={selectors.components.ConfigEditor.ClusterIDText.input}
-                data-testid={selectors.components.ConfigEditor.ClusterIDText.testID}
-              />
-            </Field>
-
-            <Field
-              hidden={!props.options.jsonData.useServerless}
-              label={selectors.components.ConfigEditor.WorkgroupText.input}
-              data-testid={selectors.components.ConfigEditor.WorkgroupText.testID}
-              htmlFor="workgroupName"
-            >
-              <ConfigSelect
-                {...props}
-                id="workgroupName"
-                label={selectors.components.ConfigEditor.WorkgroupText.input}
-                value={props.options.jsonData.workgroupName ?? ''}
-                onChange={onChangeWorkgroupName}
-                fetch={fetchWorkgroups}
-                saveOptions={saveOptions}
-                newFormStylingEnabled={true}
-              />
-            </Field>
-            <Field
-              label={selectors.components.ConfigEditor.ManagedSecret.input}
-              hidden={!useManagedSecret}
-              data-testid={selectors.components.ConfigEditor.ManagedSecret.testID}
-              htmlFor="managedSecret"
-            >
-              <ConfigSelect
-                {...props}
-                id="managedSecret"
-                label={selectors.components.ConfigEditor.ManagedSecret.input}
-                value={props.options.jsonData.managedSecret?.arn ?? ''}
-                onChange={onChangeManagedSecret}
-                fetch={fetchSecrets}
-                saveOptions={saveOptions}
-                allowCustomValue
-                newFormStylingEnabled={true}
-              />
-            </Field>
-
-            <Field
-              label={selectors.components.ConfigEditor.DatabaseUser.input}
-              hidden={props.options.jsonData.useServerless && !useManagedSecret}
-              disabled={useManagedSecret}
-              htmlFor="dbUser"
-            >
-              <Input
-                {...props}
-                id="dbUser"
-                value={props.options.jsonData.dbUser ?? ''}
-                onChange={onChange('dbUser')}
-                data-testid={selectors.components.ConfigEditor.DatabaseUser.testID}
-              />
-            </Field>
-
-            <Field label={selectors.components.ConfigEditor.Database.input}>
-              <Input
-                {...props}
-                data-testid={selectors.components.ConfigEditor.Database.testID}
-                value={props.options.jsonData.database ?? ''}
-                onChange={onChange('database')}
-              />
-            </Field>
-
-            <Field label={selectors.components.ConfigEditor.WithEvent.input} htmlFor="withEvent">
-              <Switch
-                {...props}
-                id="withEvent"
-                value={props.options.jsonData.withEvent ?? false}
-                onChange={(e) =>
-                  props.onOptionsChange({
-                    ...props.options,
-                    jsonData: {
-                      ...props.options.jsonData,
-                      withEvent: e.currentTarget.checked,
-                    },
-                  })
-                }
-                data-testid={selectors.components.ConfigEditor.WithEvent.testID}
-              />
-            </Field>
-          </ConfigSection>
-        </>
-      ) : (
-        <>
-          <h3>Redshift Details</h3>
-          <AuthTypeSwitch key="managedSecret" useManagedSecret={useManagedSecret} onChangeAuthType={onChangeAuthType} />
-          <InlineField
+      <ConnectionConfig {...props} onOptionsChange={onOptionsChange} loadRegions={fetchRegions} />
+      <Divider />
+      <ConfigSection title="Redshift Details">
+        <AuthTypeSwitch key="managedSecret" useManagedSecret={useManagedSecret} onChangeAuthType={onChangeAuthType} />
+        <Field
+          label={selectors.components.ConfigEditor.UseServerless.input}
+          data-testid={selectors.components.ConfigEditor.UseServerless.testID}
+          htmlFor="useServerless"
+        >
+          <Switch
             {...props}
-            label={selectors.components.ConfigEditor.UseServerless.input}
-            labelWidth={28}
-            style={{ alignItems: 'center' }}
-          >
-            <Switch
-              value={props.options.jsonData.useServerless}
-              onChange={(e) =>
-                props.onOptionsChange({
-                  ...props.options,
-                  jsonData: {
-                    ...props.options.jsonData,
-                    useServerless: e.currentTarget.checked,
-                  },
-                })
-              }
-              data-testid={selectors.components.ConfigEditor.UseServerless.testID}
-            />
-          </InlineField>
+            id="useServerless"
+            value={props.options.jsonData.useServerless}
+            aria-label={selectors.components.ConfigEditor.UseServerless.input}
+            onChange={(e) =>
+              props.onOptionsChange({
+                ...props.options,
+                jsonData: {
+                  ...props.options.jsonData,
+                  useServerless: e.currentTarget.checked,
+                },
+              })
+            }
+          />
+        </Field>
+        <Field
+          label={selectors.components.ConfigEditor.ClusterID.input}
+          data-testid={selectors.components.ConfigEditor.ClusterID.testID}
+          hidden={props.options.jsonData.useServerless || useManagedSecret}
+          htmlFor="clusterId"
+        >
           <ConfigSelect
             {...props}
             id="clusterId"
+            label={selectors.components.ConfigEditor.ClusterID.input}
             allowCustomValue={true}
             value={props.options.jsonData.clusterIdentifier ?? ''}
             onChange={onChangeClusterID}
             fetch={fetchClusters}
-            label={selectors.components.ConfigEditor.ClusterID.input}
-            data-testid={selectors.components.ConfigEditor.ClusterID.testID}
             saveOptions={saveOptions}
-            hidden={props.options.jsonData.useServerless || useManagedSecret}
           />
-          <InlineInput
+        </Field>
+
+        <Field
+          hidden={props.options.jsonData.useServerless || !useManagedSecret}
+          label={selectors.components.ConfigEditor.ClusterIDText.input}
+          disabled={true}
+          htmlFor="clusterIdText"
+        >
+          <Input
             {...props}
+            id="clusterIdText"
             value={props.options.jsonData.clusterIdentifier ?? ''}
             onChange={() => {}}
             label={selectors.components.ConfigEditor.ClusterIDText.input}
             data-testid={selectors.components.ConfigEditor.ClusterIDText.testID}
-            disabled={true}
-            hidden={props.options.jsonData.useServerless || !useManagedSecret}
           />
+        </Field>
+
+        <Field
+          hidden={!props.options.jsonData.useServerless}
+          label={selectors.components.ConfigEditor.WorkgroupText.input}
+          data-testid={selectors.components.ConfigEditor.WorkgroupText.testID}
+          htmlFor="workgroupName"
+        >
           <ConfigSelect
             {...props}
             id="workgroupName"
+            label={selectors.components.ConfigEditor.WorkgroupText.input}
             value={props.options.jsonData.workgroupName ?? ''}
             onChange={onChangeWorkgroupName}
             fetch={fetchWorkgroups}
-            label={selectors.components.ConfigEditor.WorkgroupText.input}
-            data-testid={selectors.components.ConfigEditor.WorkgroupText.testID}
             saveOptions={saveOptions}
-            hidden={!props.options.jsonData.useServerless}
           />
+        </Field>
+        <Field
+          label={selectors.components.ConfigEditor.ManagedSecret.input}
+          hidden={!useManagedSecret}
+          data-testid={selectors.components.ConfigEditor.ManagedSecret.testID}
+          htmlFor="managedSecret"
+        >
           <ConfigSelect
             {...props}
             id="managedSecret"
+            label={selectors.components.ConfigEditor.ManagedSecret.input}
             value={props.options.jsonData.managedSecret?.arn ?? ''}
             onChange={onChangeManagedSecret}
             fetch={fetchSecrets}
-            label={selectors.components.ConfigEditor.ManagedSecret.input}
-            data-testid={selectors.components.ConfigEditor.ManagedSecret.testID}
             saveOptions={saveOptions}
-            hidden={!useManagedSecret}
+            allowCustomValue
           />
-          <InlineInput
+        </Field>
+
+        <Field
+          label={selectors.components.ConfigEditor.DatabaseUser.input}
+          hidden={props.options.jsonData.useServerless && !useManagedSecret}
+          disabled={useManagedSecret}
+          htmlFor="dbUser"
+        >
+          <Input
             {...props}
+            id="dbUser"
             value={props.options.jsonData.dbUser ?? ''}
             onChange={onChange('dbUser')}
-            label={selectors.components.ConfigEditor.DatabaseUser.input}
             data-testid={selectors.components.ConfigEditor.DatabaseUser.testID}
-            disabled={useManagedSecret}
-            hidden={props.options.jsonData.useServerless && !useManagedSecret}
           />
-          <InlineInput
+        </Field>
+
+        <Field label={selectors.components.ConfigEditor.Database.input}>
+          <Input
             {...props}
+            data-testid={selectors.components.ConfigEditor.Database.testID}
             value={props.options.jsonData.database ?? ''}
             onChange={onChange('database')}
-            label={selectors.components.ConfigEditor.Database.input}
-            data-testid={selectors.components.ConfigEditor.Database.testID}
           />
-          <InlineField
+        </Field>
+
+        <Field label={selectors.components.ConfigEditor.WithEvent.input} htmlFor="withEvent">
+          <Switch
             {...props}
-            label={selectors.components.ConfigEditor.WithEvent.input}
-            labelWidth={28}
-            style={{ alignItems: 'center' }}
-          >
-            <Switch
-              value={props.options.jsonData.withEvent ?? false}
-              onChange={(e) =>
-                props.onOptionsChange({
-                  ...props.options,
-                  jsonData: {
-                    ...props.options.jsonData,
-                    withEvent: e.currentTarget.checked,
-                  },
-                })
-              }
-              data-testid={selectors.components.ConfigEditor.WithEvent.testID}
-            />
-          </InlineField>
-        </>
-      )}
+            id="withEvent"
+            value={props.options.jsonData.withEvent ?? false}
+            onChange={(e) =>
+              props.onOptionsChange({
+                ...props.options,
+                jsonData: {
+                  ...props.options.jsonData,
+                  withEvent: e.currentTarget.checked,
+                },
+              })
+            }
+            data-testid={selectors.components.ConfigEditor.WithEvent.testID}
+          />
+        </Field>
+      </ConfigSection>
     </div>
   );
 }

--- a/src/QueryEditorForm.test.tsx
+++ b/src/QueryEditorForm.test.tsx
@@ -1,6 +1,5 @@
 import '@testing-library/jest-dom';
 
-import * as runtime from '@grafana/runtime';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
@@ -11,7 +10,6 @@ import * as experimental from '@grafana/experimental';
 
 import { mockDatasource, mockQuery } from './__mocks__/datasource';
 import { QueryEditorForm } from './QueryEditorForm';
-import { config } from '@grafana/runtime';
 
 jest.mock('@grafana/experimental', () => ({
   ...jest.requireActual<typeof experimental>('@grafana/experimental'),
@@ -20,22 +18,8 @@ jest.mock('@grafana/experimental', () => ({
   },
 }));
 
-jest.mock('@grafana/runtime', () => ({
-  ...jest.requireActual<typeof runtime>('@grafana/runtime'),
-  config: {
-    featureToggles: {
-      awsDatasourcesNewFormStyling: false,
-    },
-  },
-}));
-
 const ds = mockDatasource;
 const q = mockQuery;
-const originalFormFeatureToggleValue = runtime.config.featureToggles.awsDatasourcesNewFormStyling;
-
-const cleanupFeatureToggle = () => {
-  config.featureToggles.awsDatasourcesNewFormStyling = originalFormFeatureToggleValue;
-};
 
 beforeEach(() => {
   ds.getResource = jest.fn().mockResolvedValue([]);
@@ -50,159 +34,121 @@ const props = {
 };
 
 describe('QueryEditorForm', () => {
-  function run() {
-    it('should request select schemas but not execute the query', async () => {
-      const onChange = jest.fn();
-      const onRunQuery = jest.fn();
-      ds.getResource = jest.fn().mockResolvedValue(['foo']);
-      render(
-        <QueryEditorForm
-          {...props}
-          onChange={onChange}
-          onRunQuery={onRunQuery}
-          query={{ ...props.query, schema: 'bar' }}
-        />
-      );
+  it('should request select schemas but not execute the query', async () => {
+    const onChange = jest.fn();
+    const onRunQuery = jest.fn();
+    ds.getResource = jest.fn().mockResolvedValue(['foo']);
+    render(
+      <QueryEditorForm
+        {...props}
+        onChange={onChange}
+        onRunQuery={onRunQuery}
+        query={{ ...props.query, schema: 'bar' }}
+      />
+    );
 
-      const selectEl = screen.getByLabelText('Schema');
-      expect(selectEl).toBeInTheDocument();
+    const selectEl = screen.getByLabelText('Schema');
+    expect(selectEl).toBeInTheDocument();
 
-      await select(selectEl, 'foo', { container: document.body });
+    await select(selectEl, 'foo', { container: document.body });
 
-      expect(ds.getResource).toHaveBeenCalledWith('schemas');
-      expect(onChange).toHaveBeenCalledWith({
-        ...q,
-        schema: 'foo',
-      });
-      expect(onRunQuery).not.toHaveBeenCalled();
+    expect(ds.getResource).toHaveBeenCalledWith('schemas');
+    expect(onChange).toHaveBeenCalledWith({
+      ...q,
+      schema: 'foo',
     });
-
-    it('should request select tables but not execute the query', async () => {
-      const onChange = jest.fn();
-      const onRunQuery = jest.fn();
-      ds.postResource = jest.fn().mockResolvedValue(['foo']);
-      render(
-        <QueryEditorForm
-          {...props}
-          onChange={onChange}
-          onRunQuery={onRunQuery}
-          query={{ ...props.query, schema: 'bar' }}
-        />
-      );
-
-      const selectEl = screen.getByLabelText('Table');
-      expect(selectEl).toBeInTheDocument();
-
-      await select(selectEl, 'foo', { container: document.body });
-
-      expect(ds.postResource).toHaveBeenCalledWith('tables', { schema: 'bar' });
-      expect(onChange).toHaveBeenCalledWith({
-        ...q,
-        schema: 'bar',
-        table: 'foo',
-      });
-      expect(onRunQuery).not.toHaveBeenCalled();
-    });
-
-    it('should request select column but not execute the query', async () => {
-      const onChange = jest.fn();
-      const onRunQuery = jest.fn();
-      ds.postResource = jest.fn().mockResolvedValue(['foo']);
-      render(
-        <QueryEditorForm
-          {...props}
-          onChange={onChange}
-          onRunQuery={onRunQuery}
-          query={{ ...props.query, table: 'bar' }}
-        />
-      );
-
-      const selectEl = screen.getByLabelText('Column');
-      expect(selectEl).toBeInTheDocument();
-
-      await select(selectEl, 'foo', { container: document.body });
-
-      expect(ds.postResource).toHaveBeenCalledWith('columns', { table: 'bar' });
-      expect(onChange).toHaveBeenCalledWith({
-        ...q,
-        table: 'bar',
-        column: 'foo',
-      });
-      expect(onRunQuery).not.toHaveBeenCalled();
-    });
-
-    it('should include the Format As input', async () => {
-      render(<QueryEditorForm {...props} />);
-      // if newFormStyling is enabled, the Format section is hidden under a Collapse
-      if (config.featureToggles.awsDatasourcesNewFormStyling) {
-        openFormatCollapse();
-      }
-      await waitFor(() =>
-        screen.getByText(config.featureToggles.awsDatasourcesNewFormStyling ? 'Format data frames as' : 'Format as')
-      );
-    });
-
-    it('should skip the fill mode input if the format is not TimeSeries', async () => {
-      const onChange = jest.fn();
-      render(
-        <QueryEditorForm
-          {...props}
-          query={{ ...props.query, format: FormatOptions.Table }}
-          queries={[]}
-          onChange={onChange}
-        />
-      );
-      // if newFormStyling is enabled, the Format section is hidden under a Collapse
-      if (config.featureToggles.awsDatasourcesNewFormStyling) {
-        openFormatCollapse();
-      }
-      await waitFor(() =>
-        screen.getByText(config.featureToggles.awsDatasourcesNewFormStyling ? 'Format data frames as' : 'Format as')
-      );
-      const selectEl = screen.queryByLabelText(
-        config.featureToggles.awsDatasourcesNewFormStyling ? 'Fill with' : 'Fill value'
-      );
-      expect(selectEl).not.toBeInTheDocument();
-    });
-
-    it('should allow to change the fill mode', async () => {
-      const onChange = jest.fn();
-      render(<QueryEditorForm {...props} queries={[]} onChange={onChange} />);
-      // if newFormStyling is enabled, the Format section is hidden under a Collapse
-      if (config.featureToggles.awsDatasourcesNewFormStyling) {
-        openFormatCollapse();
-      }
-      const selectEl = screen.getByLabelText(
-        config.featureToggles.awsDatasourcesNewFormStyling ? 'Fill with' : 'Fill value'
-      );
-      expect(selectEl).toBeInTheDocument();
-
-      await select(selectEl, 'NULL', { container: document.body });
-
-      expect(onChange).toHaveBeenCalledWith({
-        ...q,
-        fillMode: { mode: FillValueOptions.Null },
-      });
-    });
-  }
-
-  describe('QueryEditorForm with awsDatasourcesNewFormStyling feature toggle disabled', () => {
-    beforeAll(() => {
-      config.featureToggles.awsDatasourcesNewFormStyling = false;
-    });
-    afterAll(() => {
-      cleanupFeatureToggle();
-    });
-    run();
+    expect(onRunQuery).not.toHaveBeenCalled();
   });
-  describe('QueryEditorForm with awsDatasourcesNewFormStyling feature toggle enabled', () => {
-    beforeAll(() => {
-      config.featureToggles.awsDatasourcesNewFormStyling = true;
+
+  it('should request select tables but not execute the query', async () => {
+    const onChange = jest.fn();
+    const onRunQuery = jest.fn();
+    ds.postResource = jest.fn().mockResolvedValue(['foo']);
+    render(
+      <QueryEditorForm
+        {...props}
+        onChange={onChange}
+        onRunQuery={onRunQuery}
+        query={{ ...props.query, schema: 'bar' }}
+      />
+    );
+
+    const selectEl = screen.getByLabelText('Table');
+    expect(selectEl).toBeInTheDocument();
+
+    await select(selectEl, 'foo', { container: document.body });
+
+    expect(ds.postResource).toHaveBeenCalledWith('tables', { schema: 'bar' });
+    expect(onChange).toHaveBeenCalledWith({
+      ...q,
+      schema: 'bar',
+      table: 'foo',
     });
-    afterAll(() => {
-      cleanupFeatureToggle();
+    expect(onRunQuery).not.toHaveBeenCalled();
+  });
+
+  it('should request select column but not execute the query', async () => {
+    const onChange = jest.fn();
+    const onRunQuery = jest.fn();
+    ds.postResource = jest.fn().mockResolvedValue(['foo']);
+    render(
+      <QueryEditorForm
+        {...props}
+        onChange={onChange}
+        onRunQuery={onRunQuery}
+        query={{ ...props.query, table: 'bar' }}
+      />
+    );
+
+    const selectEl = screen.getByLabelText('Column');
+    expect(selectEl).toBeInTheDocument();
+
+    await select(selectEl, 'foo', { container: document.body });
+
+    expect(ds.postResource).toHaveBeenCalledWith('columns', { table: 'bar' });
+    expect(onChange).toHaveBeenCalledWith({
+      ...q,
+      table: 'bar',
+      column: 'foo',
     });
-    run();
+    expect(onRunQuery).not.toHaveBeenCalled();
+  });
+
+  it('should include the Format As input', async () => {
+    render(<QueryEditorForm {...props} />);
+    openFormatCollapse();
+    await waitFor(() => screen.getByText('Format data frames as'));
+  });
+
+  it('should skip the fill mode input if the format is not TimeSeries', async () => {
+    const onChange = jest.fn();
+    render(
+      <QueryEditorForm
+        {...props}
+        query={{ ...props.query, format: FormatOptions.Table }}
+        queries={[]}
+        onChange={onChange}
+      />
+    );
+    openFormatCollapse();
+    await waitFor(() => screen.getByText('Format data frames as'));
+    const selectEl = screen.queryByLabelText('Fill with');
+    expect(selectEl).not.toBeInTheDocument();
+  });
+
+  it('should allow to change the fill mode', async () => {
+    const onChange = jest.fn();
+    render(<QueryEditorForm {...props} queries={[]} onChange={onChange} />);
+    openFormatCollapse();
+    const selectEl = screen.getByLabelText('Fill with');
+    expect(selectEl).toBeInTheDocument();
+
+    await select(selectEl, 'NULL', { container: document.body });
+
+    expect(onChange).toHaveBeenCalledWith({
+      ...q,
+      fillMode: { mode: FillValueOptions.Null },
+    });
   });
 });
 

--- a/src/QueryEditorForm.tsx
+++ b/src/QueryEditorForm.tsx
@@ -1,13 +1,12 @@
 import { FillValueSelect, FormatSelect, ResourceSelector } from '@grafana/aws-sdk';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
-import { CollapsableSection, InlineSegmentGroup } from '@grafana/ui';
+import { CollapsableSection } from '@grafana/ui';
 import React from 'react';
 import { selectors } from 'selectors';
 import SQLEditor from './SQLEditor';
 
 import { DataSource } from './datasource';
 import { FormatOptions, RedshiftDataSourceOptions, RedshiftQuery, SelectableFormatOptions } from './types';
-import { config } from '@grafana/runtime';
 import { EditorField, EditorFieldGroup, EditorRow, EditorRows } from '@grafana/experimental';
 import { css } from '@emotion/css';
 
@@ -16,7 +15,6 @@ type Props = QueryEditorProps<DataSource, RedshiftQuery, RedshiftDataSourceOptio
 type QueryProperties = 'schema' | 'table' | 'column';
 
 export function QueryEditorForm(props: Props) {
-  const newFormStylingEnabled = config.featureToggles.awsDatasourcesNewFormStyling;
   const styles = getStyles;
 
   const fetchSchemas = async () => {
@@ -47,150 +45,93 @@ export function QueryEditorForm(props: Props) {
   };
 
   return (
-    <>
-      {newFormStylingEnabled ? (
-        <EditorRows>
-          <EditorRow>
-            <EditorFieldGroup>
-              <EditorField
-                width={20}
-                label={selectors.components.ConfigEditor.schema.input}
-                tooltip="Use the selected schema with the $__schema macro"
-                data-testid={selectors.components.ConfigEditor.schema.testID}
-                htmlFor="schema"
-              >
-                <ResourceSelector
-                  newFormStylingEnabled={true}
-                  id="schema"
-                  label={selectors.components.ConfigEditor.schema.input}
-                  onChange={onChange('schema')}
-                  fetch={fetchSchemas}
-                  value={props.query.schema || null}
-                />
-              </EditorField>
-              <EditorField
-                width={20}
-                label={selectors.components.ConfigEditor.table.input}
-                tooltip="Use the selected table with the $__table macro"
-                data-testid={selectors.components.ConfigEditor.table.testID}
-                htmlFor="table"
-              >
-                <ResourceSelector
-                  newFormStylingEnabled={true}
-                  id="table"
-                  label={selectors.components.ConfigEditor.table.input}
-                  onChange={onChange('table')}
-                  fetch={fetchTables}
-                  value={props.query.table || null}
-                  dependencies={[props.query.schema]}
-                />
-              </EditorField>
-              <EditorField
-                width={20}
-                label={selectors.components.ConfigEditor.column.input}
-                tooltip="Use the selected column with the $__column macro"
-                data-testid={selectors.components.ConfigEditor.column.testID}
-                htmlFor="column"
-              >
-                <ResourceSelector
-                  newFormStylingEnabled={true}
-                  id="column"
-                  label={selectors.components.ConfigEditor.column.input}
-                  onChange={onChange('column')}
-                  fetch={fetchColumns}
-                  value={props.query.column || null}
-                  dependencies={[props.query.table]}
-                />
-              </EditorField>
-            </EditorFieldGroup>
-          </EditorRow>
-          <EditorRow>
-            <div className={styles.collapseRow}>
-              {/* temporary solution until we have a collapse section compatible with Editor Fields in grafana/ui */}
-              <CollapsableSection
-                className={styles.collapse}
-                label={
-                  <p className={styles.collapseTitle} data-testid="collapse-title">
-                    Format
-                  </p>
-                }
-                isOpen={false}
-              >
-                <EditorFieldGroup>
-                  <EditorField label="Format data frames as" htmlFor="formatAs" width={20}>
-                    <FormatSelect
-                      newFormStylingEnabled={true}
-                      id="formatAs"
-                      query={props.query}
-                      options={SelectableFormatOptions}
-                      onChange={props.onChange}
-                    />
-                  </EditorField>
-
-                  {props.query.format === FormatOptions.TimeSeries && (
-                    <FillValueSelect newFormStylingEnabled={true} query={props.query} onChange={props.onChange} />
-                  )}
-                </EditorFieldGroup>
-              </CollapsableSection>
-            </div>
-          </EditorRow>
-          <EditorRow>
-            <div style={{ width: '100%' }}>
-              <SQLEditor query={props.query} onChange={props.onChange} datasource={props.datasource} />
-            </div>
-          </EditorRow>
-        </EditorRows>
-      ) : (
-        <InlineSegmentGroup>
-          <div className="gf-form-group">
-            <h6>Macros</h6>
+    <EditorRows>
+      <EditorRow>
+        <EditorFieldGroup>
+          <EditorField
+            width={20}
+            label={selectors.components.ConfigEditor.schema.input}
+            tooltip="Use the selected schema with the $__schema macro"
+            data-testid={selectors.components.ConfigEditor.schema.testID}
+            htmlFor="schema"
+          >
             <ResourceSelector
               id="schema"
+              label={selectors.components.ConfigEditor.schema.input}
               onChange={onChange('schema')}
               fetch={fetchSchemas}
               value={props.query.schema || null}
-              tooltip="Use the selected schema with the $__schema macro"
-              label={selectors.components.ConfigEditor.schema.input}
-              data-testid={selectors.components.ConfigEditor.schema.testID}
-              labelWidth={11}
-              className="width-12"
             />
+          </EditorField>
+          <EditorField
+            width={20}
+            label={selectors.components.ConfigEditor.table.input}
+            tooltip="Use the selected table with the $__table macro"
+            data-testid={selectors.components.ConfigEditor.table.testID}
+            htmlFor="table"
+          >
             <ResourceSelector
               id="table"
+              label={selectors.components.ConfigEditor.table.input}
               onChange={onChange('table')}
               fetch={fetchTables}
               value={props.query.table || null}
               dependencies={[props.query.schema]}
-              tooltip="Use the selected table with the $__table macro"
-              label={selectors.components.ConfigEditor.table.input}
-              data-testid={selectors.components.ConfigEditor.table.testID}
-              labelWidth={11}
-              className="width-12"
             />
+          </EditorField>
+          <EditorField
+            width={20}
+            label={selectors.components.ConfigEditor.column.input}
+            tooltip="Use the selected column with the $__column macro"
+            data-testid={selectors.components.ConfigEditor.column.testID}
+            htmlFor="column"
+          >
             <ResourceSelector
               id="column"
+              label={selectors.components.ConfigEditor.column.input}
               onChange={onChange('column')}
               fetch={fetchColumns}
               value={props.query.column || null}
               dependencies={[props.query.table]}
-              tooltip="Use the selected column with the $__column macro"
-              label={selectors.components.ConfigEditor.column.input}
-              data-testid={selectors.components.ConfigEditor.column.testID}
-              labelWidth={11}
-              className="width-12"
             />
-            <h6>Frames</h6>
-            <FormatSelect query={props.query} options={SelectableFormatOptions} onChange={props.onChange} />
-            {props.query.format === FormatOptions.TimeSeries && (
-              <FillValueSelect query={props.query} onChange={props.onChange} />
-            )}
-          </div>
-          <div style={{ minWidth: '400px', marginLeft: '10px', flex: 1 }}>
-            <SQLEditor query={props.query} onChange={props.onChange} datasource={props.datasource} />
-          </div>
-        </InlineSegmentGroup>
-      )}
-    </>
+          </EditorField>
+        </EditorFieldGroup>
+      </EditorRow>
+      <EditorRow>
+        <div className={styles.collapseRow}>
+          {/* temporary solution until we have a collapse section compatible with Editor Fields in grafana/ui */}
+          <CollapsableSection
+            className={styles.collapse}
+            label={
+              <p className={styles.collapseTitle} data-testid="collapse-title">
+                Format
+              </p>
+            }
+            isOpen={false}
+          >
+            <EditorFieldGroup>
+              <EditorField label="Format data frames as" htmlFor="formatAs" width={20}>
+                <FormatSelect
+                  id="formatAs"
+                  query={props.query}
+                  options={SelectableFormatOptions}
+                  onChange={props.onChange}
+                />
+              </EditorField>
+
+              {props.query.format === FormatOptions.TimeSeries && (
+                <FillValueSelect query={props.query} onChange={props.onChange} />
+              )}
+            </EditorFieldGroup>
+          </CollapsableSection>
+        </div>
+      </EditorRow>
+      <EditorRow>
+        <div style={{ width: '100%' }}>
+          <SQLEditor query={props.query} onChange={props.onChange} datasource={props.datasource} />
+        </div>
+      </EditorRow>
+    </EditorRows>
   );
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1578,10 +1578,10 @@
   dependencies:
     tslib "^2.4.1"
 
-"@grafana/aws-sdk@0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.3.1.tgz#0ada1b06c13882320ae2c07e7b2bbd703091da7c"
-  integrity sha512-YwJhe89qhYmpKWcP4smI90f+AB7C70mYcASnczZ9jGevOt8I8T6rQwTlsMJIoDXYMqYTpOzqi2FYemu/knSCqQ==
+"@grafana/aws-sdk@0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.4.0.tgz#bc5192c48b47ca0911ba2ac777923abd337d1074"
+  integrity sha512-42OBqjb0zgEy1jgteg8llkz55p0r0GZGYxzxfLXHpqGQwqkextUO+axlGjRuylKl50d+XArZEvUNj4JWRGp23w==
   dependencies:
     "@grafana/async-query-data" "0.1.4"
     "@grafana/experimental" "1.7.0"


### PR DESCRIPTION
Removes the newFormStyling feature toggle, making the new styling default. Part of https://github.com/grafana/oss-plugin-partnerships/issues/692