### PR TITLE
Fix: use ReadAuthSettings to get authSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.15.2
+
+- Fix: use ReadAuthSettings to get authSettings in [#288](https://github.com/grafana/redshift-datasource/pull/288)
+
 ## 1.15.1
 
 - Upgrade grafana-aws-sdk to replace `GetSession` usages with `GetSessionWithAuthSettings` [#284](https://github.com/grafana/redshift-datasource/pull/284)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-redshift-datasource",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "description": "Use Amazon Redshift in Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/pkg/redshift/api/api.go
+++ b/pkg/redshift/api/api.go
@@ -48,7 +48,7 @@ func New(ctx context.Context, sessionCache *awsds.SessionCache, settings awsMode
 		return nil, err
 	}
 
-	authSettings, _ := awsds.ReadAuthSettingsFromContext(ctx)
+	authSettings := awsds.ReadAuthSettings(ctx)
 	sess, err := sessionCache.GetSessionWithAuthSettings(awsds.GetSessionConfig{
 		Settings:      redshiftSettings.AWSDatasourceSettings,
 		HTTPClient:    httpClient,


### PR DESCRIPTION
Uses ReadAuthSettings which tries to read auth settings from context first and then automatically falls back to reading auth settings from the environment.

Also includes the changes for releasing these changes.