### PR TITLE
Prepare release 1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.16.0
+
+-  Migrate to new form styling in config and query editors in [#287](https://github.com/grafana/redshift-datasource/pull/287) 
+
 ## 1.15.2
 
 - Fix: use ReadAuthSettings to get authSettings in [#288](https://github.com/grafana/redshift-datasource/pull/288)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-redshift-datasource",
-  "version": "1.15.2",
+  "version": "1.16.0",
   "description": "Use Amazon Redshift in Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
## 1.16.0

-  Migrate to new form styling in config and query editors in [#287](https://github.com/grafana/redshift-datasource/pull/287) 