### PR TITLE
Update grafana/aws-sdk to get correct regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.17.0
+
+-  Update grafana/aws-sdk to get new regions 
+
 ## 1.16.0
 
 -  Migrate to new form styling in config and query editors in [#287](https://github.com/grafana/redshift-datasource/pull/287) 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-redshift-datasource",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Use Amazon Redshift in Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
@@ -33,7 +33,7 @@
   "devDependencies": {
     "@babel/core": "^7.21.4",
     "@emotion/css": "^11.1.3",
-    "@grafana/aws-sdk": "0.4.0",
+    "@grafana/aws-sdk": "0.4.1",
     "@grafana/data": "10.2.0",
     "@grafana/e2e": "10.2.0",
     "@grafana/e2e-selectors": "10.0.0",

--- a/pkg/redshift/api/api.go
+++ b/pkg/redshift/api/api.go
@@ -171,40 +171,8 @@ func (c *API) Stop(output *api.ExecuteQueryOutput) error {
 }
 
 func (c *API) Regions(aws.Context) ([]string, error) {
-	// List from https://docs.aws.amazon.com/general/latest/gr/redshift-service.html
-	return []string{
-		"us-east-2",
-		"us-east-1",
-		"us-west-1",
-		"us-west-2",
-		"af-south-1",
-		"ap-east-1",
-		"ap-south-2",
-		"ap-southeast-3",
-		"ap-southeast-4",
-		"ap-south-1",
-		"ap-northeast-3",
-		"ap-northeast-2",
-		"ap-southeast-1",
-		"ap-southeast-2",
-		"ap-northeast-1",
-		"ca-central-1",
-		"ca-west-1",
-		"eu-central-1",
-		"eu-west-1",
-		"eu-west-2",
-		"eu-south-1",
-		"eu-west-3",
-		"eu-south-2",
-		"eu-north-1",
-		"eu-central-2",
-		"il-central-1",
-		"me-south-1",
-		"me-central-1",
-		"sa-east-1",
-		"us-gov-east-1",
-		"us-gov-west-1",
-	}, nil
+	// This is not used. If regions are out of date, update them in the @grafana/aws-sdk-react package
+	return []string{}, nil
 }
 
 func (c *API) Databases(ctx aws.Context, options sqlds.Options) ([]string, error) {

--- a/pkg/redshift/datasource.go
+++ b/pkg/redshift/datasource.go
@@ -113,6 +113,7 @@ func (s *RedshiftDatasource) getApi(ctx context.Context, options sqlds.Options) 
 }
 
 func (s *RedshiftDatasource) Regions(ctx context.Context) ([]string, error) {
+	// This is not used. If regions are out of date, update them in the @grafana/aws-sdk-react package
 	return []string{}, nil
 }
 

--- a/pkg/redshift/datasource.go
+++ b/pkg/redshift/datasource.go
@@ -113,15 +113,7 @@ func (s *RedshiftDatasource) getApi(ctx context.Context, options sqlds.Options) 
 }
 
 func (s *RedshiftDatasource) Regions(ctx context.Context) ([]string, error) {
-	api, err := s.getApi(ctx, sqlds.Options{})
-	if err != nil {
-		return nil, err
-	}
-	regions, err := api.Regions(ctx)
-	if err != nil {
-		return nil, err
-	}
-	return regions, nil
+	return []string{}, nil
 }
 
 func (s *RedshiftDatasource) Databases(ctx context.Context, options sqlds.Options) ([]string, error) {

--- a/src/ConfigEditor/ConfigEditor.tsx
+++ b/src/ConfigEditor/ConfigEditor.tsx
@@ -116,12 +116,6 @@ export function ConfigEditor(props: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [arn]);
 
-  // Regions
-  const fetchRegions = async () => {
-    const regions: string[] = await getBackendSrv().get(resourcesURL + '/regions');
-    return regions;
-  };
-
   // Clusters
   const [clusterEndpoint, setClusterEndpoint] = useState('');
   const fetchClusters = async () => {
@@ -247,7 +241,7 @@ export function ConfigEditor(props: Props) {
 
   return (
     <div className={styles.formStyles}>
-      <ConnectionConfig {...props} onOptionsChange={onOptionsChange} loadRegions={fetchRegions} />
+      <ConnectionConfig {...props} onOptionsChange={onOptionsChange} />
       <Divider />
       <ConfigSection title="Redshift Details">
         <AuthTypeSwitch key="managedSecret" useManagedSecret={useManagedSecret} onChangeAuthType={onChangeAuthType} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1564,13 +1564,6 @@
   dependencies:
     tslib "^2.4.0"
 
-"@grafana/async-query-data@0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@grafana/async-query-data/-/async-query-data-0.1.4.tgz#ac24e32822a8032dd1ee10ce7dcb8c2e276c58b0"
-  integrity sha512-3d7fm2sf5x/+JKTt4T6MSS/veB2J/YGfQp5Ck0Tbqtc5YIoI0p1JY+vFWfCstEHyVd1H0Ep/q/VSxf4VAs9YKQ==
-  dependencies:
-    tslib "^2.4.1"
-
 "@grafana/async-query-data@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@grafana/async-query-data/-/async-query-data-0.2.0.tgz#2df8a69da527ce1993fc74a6bce452582fb76649"
@@ -1578,13 +1571,13 @@
   dependencies:
     tslib "^2.4.1"
 
-"@grafana/aws-sdk@0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.4.0.tgz#bc5192c48b47ca0911ba2ac777923abd337d1074"
-  integrity sha512-42OBqjb0zgEy1jgteg8llkz55p0r0GZGYxzxfLXHpqGQwqkextUO+axlGjRuylKl50d+XArZEvUNj4JWRGp23w==
+"@grafana/aws-sdk@0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@grafana/aws-sdk/-/aws-sdk-0.4.1.tgz#0f8051486d624c3ad612d081240909ac74fa47e1"
+  integrity sha512-qW32oZH0iu6sZGh0nD/k7ThDf2+8xuIxMqh+u4ObMOy+EfUi4NzeXQtIf0b/3BycUk5gJSZG930hmnCvOUFd8w==
   dependencies:
-    "@grafana/async-query-data" "0.1.4"
-    "@grafana/experimental" "1.7.0"
+    "@grafana/async-query-data" "0.2.0"
+    "@grafana/experimental" "1.7.12"
 
 "@grafana/data@10.2.0":
   version "10.2.0"
@@ -1677,6 +1670,20 @@
   integrity sha512-3DfDzGTUnvG/v2U0lhBaB05j4x0bczrgylrg5Co6LMyRYh1kPA4XnK0dTshSxA6igjKqAjSacfwZQ40f4rLdqw==
   dependencies:
     "@types/uuid" "^8.3.3"
+    uuid "^8.3.2"
+
+"@grafana/experimental@1.7.12":
+  version "1.7.12"
+  resolved "https://registry.yarnpkg.com/@grafana/experimental/-/experimental-1.7.12.tgz#7fe0be35a4d5b242861afc5b4449dac3df761b97"
+  integrity sha512-Yp9TrfB42y/loeKqZWhuSVFgFYx6182Xx8FzrWlDdnJBmV5rlys7cX/RsIzf+6lcruJhrwtWCvACFwNeAjhPgg==
+  dependencies:
+    "@types/uuid" "^8.3.3"
+    lodash "^4.17.21"
+    prismjs "^1.29.0"
+    react-beautiful-dnd "^13.1.1"
+    react-popper-tooltip "^4.4.2"
+    react-use "^17.4.2"
+    semver "^7.5.4"
     uuid "^8.3.2"
 
 "@grafana/faro-core@^1.2.1":
@@ -2129,6 +2136,11 @@
   version "1.4.15"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz#d7c6e6755c78567a951e04ab52ef0fd26de59f32"
   integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+
+"@jridgewell/sourcemap-codec@^1.4.15":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
+  integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
 
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
@@ -4653,6 +4665,11 @@ csstype@^3.0.2, csstype@^3.0.6:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
   integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
 
+csstype@^3.1.2:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
+  integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
+
 cypress-file-upload@5.0.8:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz#d8824cbeaab798e44be8009769f9a6c9daa1b4a1"
@@ -6703,6 +6720,13 @@ inline-style-prefixer@^6.0.0:
     css-in-js-utils "^3.1.0"
     fast-loops "^1.1.3"
 
+inline-style-prefixer@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-7.0.1.tgz#9310f3cfa2c6f3901d1480f373981c02691781e8"
+  integrity sha512-lhYo5qNTQp3EvSSp3sRvXMbVQTLrvGV6DycRMJ5dm2BLMiJ30wpXKdDdgX+GmJZ5uQMucwRKHamXSst3Sj/Giw==
+  dependencies:
+    css-in-js-utils "^3.1.0"
+
 internal-slot@^1.0.4, internal-slot@^1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/internal-slot/-/internal-slot-1.0.6.tgz#37e756098c4911c5e912b8edbf71ed3aa116f930"
@@ -8111,6 +8135,20 @@ nano-css@^5.3.1:
     stacktrace-js "^2.0.2"
     stylis "^4.0.6"
 
+nano-css@^5.6.2:
+  version "5.6.2"
+  resolved "https://registry.yarnpkg.com/nano-css/-/nano-css-5.6.2.tgz#584884ddd7547278f6d6915b6805069742679a32"
+  integrity sha512-+6bHaC8dSDGALM1HJjOHVXpuastdu2xFoZlC77Jh4cg+33Zcgm+Gxd+1xsnpZK14eyHObSp82+ll5y3SX75liw==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.4.15"
+    css-tree "^1.1.2"
+    csstype "^3.1.2"
+    fastest-stable-stringify "^2.0.2"
+    inline-style-prefixer "^7.0.1"
+    rtl-css-js "^1.16.1"
+    stacktrace-js "^2.0.2"
+    stylis "^4.3.0"
+
 nanoid@3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
@@ -8641,7 +8679,7 @@ pretty-format@^29.0.0, pretty-format@^29.7.0:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
-prismjs@1.29.0:
+prismjs@1.29.0, prismjs@^1.29.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.29.0.tgz#f113555a8fa9b57c35e637bba27509dcf802dd12"
   integrity sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==
@@ -8972,7 +9010,7 @@ rc-virtual-list@^3.5.1, rc-virtual-list@^3.5.2:
     rc-resize-observer "^1.0.0"
     rc-util "^5.36.0"
 
-react-beautiful-dnd@13.1.1:
+react-beautiful-dnd@13.1.1, react-beautiful-dnd@^13.1.1:
   version "13.1.1"
   resolved "https://registry.yarnpkg.com/react-beautiful-dnd/-/react-beautiful-dnd-13.1.1.tgz#b0f3087a5840920abf8bb2325f1ffa46d8c4d0a2"
   integrity sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==
@@ -9100,7 +9138,7 @@ react-loading-skeleton@3.3.1:
   resolved "https://registry.yarnpkg.com/react-loading-skeleton/-/react-loading-skeleton-3.3.1.tgz#cd6e3a626ee86c76a46c14e2379243f2f8834e1b"
   integrity sha512-NilqqwMh2v9omN7LteiDloEVpFyMIa0VGqF+ukqp0ncVlYu1sKYbYGX9JEl+GtOT9TKsh04zCHAbavnQ2USldA==
 
-react-popper-tooltip@4.4.2:
+react-popper-tooltip@4.4.2, react-popper-tooltip@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/react-popper-tooltip/-/react-popper-tooltip-4.4.2.tgz#0dc4894b8e00ba731f89bd2d30584f6032ec6163"
   integrity sha512-y48r0mpzysRTZAIh8m2kpZ8S1YPNqGtQPDrlXYSGvDS1c1GpG/NUXbsbIdfbhXfmSaRJuTcaT6N1q3CKuHRVbg==
@@ -9212,6 +9250,26 @@ react-use@17.4.0:
     fast-shallow-equal "^1.0.0"
     js-cookie "^2.2.1"
     nano-css "^5.3.1"
+    react-universal-interface "^0.6.2"
+    resize-observer-polyfill "^1.5.1"
+    screenfull "^5.1.0"
+    set-harmonic-interval "^1.0.1"
+    throttle-debounce "^3.0.1"
+    ts-easing "^0.2.0"
+    tslib "^2.1.0"
+
+react-use@^17.4.2:
+  version "17.5.1"
+  resolved "https://registry.yarnpkg.com/react-use/-/react-use-17.5.1.tgz#19fc2ae079775d8450339e9fa8dbe25b17f2263c"
+  integrity sha512-LG/uPEVRflLWMwi3j/sZqR00nF6JGqTTDblkXK2nzXsIvij06hXl1V/MZIlwj1OKIQUtlh1l9jK8gLsRyCQxMg==
+  dependencies:
+    "@types/js-cookie" "^2.2.6"
+    "@xobotyi/scrollbar-width" "^1.9.5"
+    copy-to-clipboard "^3.3.1"
+    fast-deep-equal "^3.1.3"
+    fast-shallow-equal "^1.0.0"
+    js-cookie "^2.2.1"
+    nano-css "^5.6.2"
     react-universal-interface "^0.6.2"
     resize-observer-polyfill "^1.5.1"
     screenfull "^5.1.0"
@@ -9533,7 +9591,7 @@ robust-predicates@^3.0.0:
   resolved "https://registry.yarnpkg.com/robust-predicates/-/robust-predicates-3.0.2.tgz#d5b28528c4824d20fc48df1928d41d9efa1ad771"
   integrity sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==
 
-rtl-css-js@^1.14.0:
+rtl-css-js@^1.14.0, rtl-css-js@^1.16.1:
   version "1.16.1"
   resolved "https://registry.yarnpkg.com/rtl-css-js/-/rtl-css-js-1.16.1.tgz#4b48b4354b0ff917a30488d95100fbf7219a3e80"
   integrity sha512-lRQgou1mu19e+Ya0LsTvKrVJ5TYUbqCVPAiImX3UfLTenarvPUl1QFdvu5Z3PYmHT9RCcwIfbjRQBntExyj3Zg==
@@ -10168,6 +10226,11 @@ stylis@^4.0.6:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.3.0.tgz#abe305a669fc3d8777e10eefcfc73ad861c5588c"
   integrity sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ==
+
+stylis@^4.3.0:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.3.2.tgz#8f76b70777dd53eb669c6f58c997bf0a9972e444"
+  integrity sha512-bhtUjWd/z6ltJiQwg0dUfxEJ+W+jdqQd8TbWLWyeIJHlnsqmGLRFFd8e5mA0AZi/zx90smXRlN66YMTcaSFifg==
 
 supports-color@8.1.1, supports-color@^8.0.0, supports-color@^8.1.1:
   version "8.1.1"


### PR DESCRIPTION
This does the same thing as in Athena: https://github.com/grafana/athena-datasource/pull/341
We decided to populate the regions from @grafana/aws-sdk-react repo instead of the datasource's BE. This is easier as we will only need to update them in one place when we need to. 
Also removes some unused code from the BE. 

Fixes https://github.com/grafana/redshift-datasource/issues/290