### PR TITLE
Add error source and 1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.18.0
+
+-  Add errorsource in [#292](https://github.com/grafana/redshift-datasource/pull/292) 
+
 ## 1.17.0
 
 -  Update grafana/aws-sdk to get new regions 

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -91,6 +91,7 @@
     "instancemgmt",
     "opentelemetry",
     "httptrace",
-    "otelhttptrace"
+    "otelhttptrace",
+    "errorsource"
   ]
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.21.3
 require (
 	github.com/aws/aws-sdk-go v1.51.31
 	github.com/google/go-cmp v0.6.0
-	github.com/grafana/grafana-aws-sdk v0.27.0
+	github.com/grafana/grafana-aws-sdk v0.30.0
 	github.com/grafana/grafana-plugin-sdk-go v0.228.0
 	github.com/grafana/sqlds/v3 v3.2.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -71,6 +71,8 @@ github.com/grafana/dataplane/sdata v0.0.9 h1:AGL1LZnCUG4MnQtnWpBPbQ8ZpptaZs14w6k
 github.com/grafana/dataplane/sdata v0.0.9/go.mod h1:Jvs5ddpGmn6vcxT7tCTWAZ1mgi4sbcdFt9utQx5uMAU=
 github.com/grafana/grafana-aws-sdk v0.27.0 h1:i8YWYr2S0/xKvSlltDEJBnTz5bWYz4vpiNPt9hcJ1Qs=
 github.com/grafana/grafana-aws-sdk v0.27.0/go.mod h1:ZSVPU7IIJSi5lEg+K3Js+EUpZLXxUaBdaQWH+As1ihI=
+github.com/grafana/grafana-aws-sdk v0.30.0 h1:6IIetM4s2NbvPOI4/fefsyN84BIb0/T09lHGF/pywo8=
+github.com/grafana/grafana-aws-sdk v0.30.0/go.mod h1:ZSVPU7IIJSi5lEg+K3Js+EUpZLXxUaBdaQWH+As1ihI=
 github.com/grafana/grafana-plugin-sdk-go v0.228.0 h1:LlPqyB+RZTtDy8RVYD7iQVJW5A0gMoGSI/+Ykz8HebQ=
 github.com/grafana/grafana-plugin-sdk-go v0.228.0/go.mod h1:u4K9vVN6eU86loO68977eTXGypC4brUCnk4sfDzutZU=
 github.com/grafana/sqlds/v3 v3.2.0 h1:WXuYEaFfiCvgm8kK2ixx44/zAEjFzCylA2+RF3GBqZA=

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-redshift-datasource",
-  "version": "1.17.0",
+  "version": "1.18.0",
   "description": "Use Amazon Redshift in Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",


### PR DESCRIPTION
Adds error source for downstream errors for flows in QueryData. This doesn't add error source for errors returned from resource handlers because source labelling still doesn't work for them. 
We're working on getting it captured there too, but the implementation might change, so we're doing the bare minimum here.

Equivalent PR in Athena: https://github.com/grafana/athena-datasource/pull/344