### PR TITLE
fix: don't check slice nilness before checking length

### DIFF
--- a/pkg/redshift/models/settings.go
+++ b/pkg/redshift/models/settings.go
@@ -56,7 +56,7 @@ func New(_ context.Context) models.Settings {
 }
 
 func (s *RedshiftDataSourceSettings) Load(config backend.DataSourceInstanceSettings) error {
-	if config.JSONData != nil && len(config.JSONData) > 1 {
+	if len(config.JSONData) > 1 {
 		if err := json.Unmarshal(config.JSONData, s); err != nil {
 			return fmt.Errorf("could not unmarshal DatasourceSettings json: %w", err)
 		}


### PR DESCRIPTION
The latest version of golangci-lint makes this an error; this will prevent PR failures [like those we're seeing in the athena datasource](https://github.com/grafana/athena-datasource/pulls).