### PR TITLE
Add dependabot for grafana/plugin-sdk-go

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    allow:
+      # Keep the sdk modules up-to-date
+      - dependency-name: "github.com/grafana/grafana-plugin-sdk-go"
+        dependency-type: "all"
+    commit-message:
+      prefix: "Upgrade grafana-plugin-sdk-go "
+      include: "scope"

--- a/cspell.config.json
+++ b/cspell.config.json
@@ -92,6 +92,7 @@
     "opentelemetry",
     "httptrace",
     "otelhttptrace",
-    "errorsource"
+    "errorsource",
+    "gomod"
   ]
 }


### PR DESCRIPTION
<!-- Thank you for sending a pull request! Here are some tips:

1. To surface this PR in the changelog add the label: changelog
    If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way:
        Bad: fix state bug in hooks
        Good: Fix crash when switching from Query Builder

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, consider updating the documentation in README.md(https://github.com/grafana/opensearch-datasource/blob/main/README.md).
-->

**What this PR does / why we need it**:
This adds dependabot just for plugin-sdk-go. The purpose of this is to keep the sdk up to date with the latest observability features for api server: https://github.com/grafana/data-sources/issues/64. This is temporary while decide on our general dependabot process. 
(needs to be enabled in settings once this is merged)
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
