### PR TITLE
Add PDC support

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-dom": "18.3.1",
     "react-router-dom": "^7.1.1",
     "react-router-dom-v5-compat": "^6.28.1",
+    "semver": "^7.6.3",
     "tslib": "2.8.1"
   },
   "devDependencies": {

--- a/src/ConfigEditor/ConfigEditor.tsx
+++ b/src/ConfigEditor/ConfigEditor.tsx
@@ -1,6 +1,8 @@
 import { ConfigSelect, ConnectionConfig, Divider } from '@grafana/aws-sdk';
 import { DataSourcePluginOptionsEditorProps, SelectableValue, GrafanaTheme2 } from '@grafana/data';
-import { getBackendSrv } from '@grafana/runtime';
+import { config, getBackendSrv } from '@grafana/runtime';
+import { Field, Input, SecureSocksProxySettings, Switch, useStyles2 } from '@grafana/ui';
+import { gte } from 'semver';
 import React, { FormEvent, useEffect, useState } from 'react';
 import { selectors } from 'selectors';
 
@@ -11,7 +13,6 @@ import {
   RedshiftManagedSecret,
 } from '../types';
 import { AuthTypeSwitch } from './AuthTypeSwitch';
-import { Field, Input, Switch, useStyles2 } from '@grafana/ui';
 import { css } from '@emotion/css';
 import { ConfigSection } from '@grafana/experimental';
 
@@ -242,6 +243,9 @@ export function ConfigEditor(props: Props) {
   return (
     <div className={styles.formStyles}>
       <ConnectionConfig {...props} onOptionsChange={onOptionsChange} />
+      {config.secureSocksDSProxyEnabled && gte(config.buildInfo.version, '10.0.0') && (
+        <SecureSocksProxySettings options={props.options} onOptionsChange={onOptionsChange} />
+      )}
       <Divider />
       <ConfigSection title="Redshift Details">
         <AuthTypeSwitch key="managedSecret" useManagedSecret={useManagedSecret} onChangeAuthType={onChangeAuthType} />

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,7 @@ export interface RedshiftDataSourceOptions extends AwsAuthDataSourceJsonData {
     name: string;
     arn: string;
   };
+  enableSecureSocksProxy?: boolean;
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/grafana/oss-plugin-partnerships/issues/1127

[Instructions for testing PDC locally](https://wiki.grafana-ops.net/w/index.php/Engineering/Grafana/Data_Sources/API_servers/Testing_datasources_with_PDC_Locally)

New secure socks proxy setting added below the region selector in the config page

<img width="484" alt="redshift" src="https://github.com/user-attachments/assets/4c1cf2e7-fd6a-4fd9-b29b-08c2a48bd513" />
