### PR TITLE
Github workflows: Don't use hash for grafana actions and add permissions for PRs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
       - name: Resolve Grafana E2E versions
         id: resolve-versions
-        uses: grafana/plugin-actions/e2e-version@c233e9f6752186a9b256a2a451ec3067fbf712c2 # main
+        uses: grafana/plugin-actions/e2e-version@main
         with:
           version-resolver-type: version-support-policy
 
@@ -78,7 +78,7 @@ jobs:
           GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} ACCESS_KEY=${{env.ACCESS_KEY}} SECRET_KEY=${{env.SECRET_KEY}} docker compose up -d
 
       - name: Wait for grafana server
-        uses: grafana/plugin-actions/wait-for-grafana@c233e9f6752186a9b256a2a451ec3067fbf712c2 # main
+        uses: grafana/plugin-actions/wait-for-grafana@main
 
       - name: Run Playwright tests
         id: run-tests

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -12,6 +12,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      # The "id-token: write" permission is required by "get-vault-secrets" action
+      id-token: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions


### PR DESCRIPTION
unpin grafana owned actions as they are excluded in the zizmor config. add id-token permission for get-vault-secrets action