### PR TITLE
Chore: Migrate to Github actions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,47 @@
+name: Plugins - CD
+run-name: Deploy ${{ inputs.branch }} to ${{ inputs.environment }} by @${{ github.actor }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Branch to publish from. Can be used to deploy PRs to dev
+        default: main
+      environment:
+        description: Environment to publish to
+        required: true
+        type: choice
+        options:
+          - "dev"
+          - "ops"
+          - "prod"
+      docs-only:
+        description: Only publish docs, do not publish the plugin
+        default: false
+        type: boolean
+
+permissions: {}
+
+jobs:
+  cd:
+    name: CD
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@main # zizmor: ignore[unpinned-uses]
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    with:
+      branch: ${{ github.event.inputs.branch }}
+      environment: ${{ github.event.inputs.environment }}
+      docs-only: ${{ fromJSON(github.event.inputs.docs-only) }}
+      golangci-lint-version: '2.1.6'
+      # the shared workflow doesn't have a mechanism to specify custom Vault secrets in e2e tests, so we're using the workflow in e2e-tests.yml instead
+      run-playwright: false
+
+      # Scope for the plugin published to the catalog. Setting this to "grafana_cloud" will make it visible only in Grafana Cloud
+      # (and hide it for on-prem). This is required for some provisioned plugins.
+      # scopes: grafana_cloud
+
+      # Also deploy the plugin to Grafana Cloud via Argo. You also have to follow the Argo Workflows setup guide for this to work.
+      # grafana-cloud-deployment-type: provisioned
+      # argo-workflow-slack-channel: "#grafana-plugins-platform-ci"

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,0 +1,22 @@
+name: Plugins - CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions: {}
+
+jobs:
+  ci:
+    name: CI
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@main # zizmor: ignore[unpinned-uses]
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
+      golangci-lint-version: '2.1.6'
+      # the shared workflow doesn't have a mechanism to specify custom Vault secrets in e2e tests, so we're using the workflow in e2e-tests.yml instead
+      run-playwright: false

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "@types/lodash": "^4.17.16",
     "@types/node": "^22.15.17",
     "@types/semver": "^7.7.0",
-    "@types/testing-library__jest-dom": "6.0.0",
     "@typescript-eslint/eslint-plugin": "^8.32.1",
     "@typescript-eslint/parser": "^8.32.1",
     "copy-webpack-plugin": "^13.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1984,7 +1984,7 @@
     lz-string "^1.5.0"
     pretty-format "^27.0.2"
 
-"@testing-library/jest-dom@*", "@testing-library/jest-dom@6.6.3":
+"@testing-library/jest-dom@6.6.3":
   version "6.6.3"
   resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz#26ba906cf928c0f8172e182c6fe214eb4f9f2bd2"
   dependencies:
@@ -2213,12 +2213,6 @@
 "@types/systemjs@6.15.1":
   version "6.15.1"
   resolved "https://registry.yarnpkg.com/@types/systemjs/-/systemjs-6.15.1.tgz#dae1ec2fbe66af7c6ca1a110e2c9ca6b85135eec"
-
-"@types/testing-library__jest-dom@6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-6.0.0.tgz#b558b64b80a72130714be1f505c6df482d453690"
-  dependencies:
-    "@testing-library/jest-dom" "*"
 
 "@types/tough-cookie@*":
   version "4.0.5"


### PR DESCRIPTION
Blocked by and checked out from: https://github.com/grafana/redshift-datasource/pull/408

This migrates the plugin CI/CD processes to Github actions according to [this migration guide](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/020-migrating-form-drone/)

Right now the shared workflows don't have a mechanism to specify custom Vault secrets in e2e tests, so I had to disable the shared e2e workflow and keep our old e2e action. This might change in the future, but with drone sunset coming up, we don't really have a choice. More info [in this thread ](https://raintank-corp.slack.com/archives/C01C4K8DETW/p1750077883269419?thread_ts=1750072014.548489&cid=C01C4K8DETW)

