### PR TITLE
aggregate e2e status checks

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -93,3 +93,19 @@ jobs:
       #     name: playwright-report-${{ matrix.GRAFANA_IMAGE.NAME }}-v${{ matrix.GRAFANA_IMAGE.VERSION }}-${{github.run_id}}
       #     path: playwright-report/
       #     retention-days: 30
+
+  check-playwright-status:
+    needs: playwright-tests
+    name: Check Playwright E2E matrix status
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check matrix job status
+        # This step will fail if any of the matrix jobs failed
+        run: |
+          if [ "${{ contains(needs.playwright-tests.result, 'failure') }}" = "true" ]; then
+            echo "One or more jobs in the E2E testing matrix failed"
+            exit 1
+          else
+            echo "All E2E test jobs succeeded"
+          fi


### PR DESCRIPTION
Added an extra step to the e2e workflow. This is to be able to make the e2e tests a required check before PRs can be merged (useful for automerging dependabot PRs). This is needed because the e2e workflow is a matrix job so we can't know in advance what the e2e jobs will be named so we need to aggregate all the matrix jobs and check if all of them have succeeded. This is only needed because we haven't fully migrated to the new CI workflow.