### PR TITLE
Set the default format to table

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -4,13 +4,17 @@ import { DataSourceInstanceSettings, ScopedVars } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 import { RedshiftVariableSupport } from 'variables';
 
-import { RedshiftDataSourceOptions, RedshiftQuery } from './types';
+import { RedshiftDataSourceOptions, RedshiftQuery, defaultQuery } from './types';
 import { RedshiftAnnotationsSupport } from './annotations';
 
 export class DataSource extends DatasourceWithAsyncBackend<RedshiftQuery, RedshiftDataSourceOptions> {
   constructor(instanceSettings: DataSourceInstanceSettings<RedshiftDataSourceOptions>) {
     super(instanceSettings);
     this.variables = new RedshiftVariableSupport(this);
+  }
+
+  getDefaultQuery(): Partial<RedshiftQuery> {
+    return defaultQuery;
   }
 
   // This will support annotation queries for 7.2+

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,7 @@ export const defaultKey = '__default';
 
 export const defaultQuery: Partial<RedshiftQuery> = {
   rawSQL: '',
-  format: FormatOptions.TimeSeries,
+  format: FormatOptions.Table,
   fillMode: { mode: FillValueOptions.Previous },
 };
 


### PR DESCRIPTION
Currently, queries return results formatted as a time series. Which can lead to issues as described in https://github.com/grafana/redshift-datasource/issues/383

In our [docs](https://github.com/grafana/redshift-datasource/blob/ecffe27b17384ee5699ed5674ac8067fcc4a89fd/README.md?plain=1#L109-L144), it's mentioned that most queries are best represented as tables and there are requirements that must be met in order for a query to be visualized as a time series.

This PR sets the default format of new queries to be "table". This also matches our other SQL-based data sources: [Athena](https://github.com/grafana/athena-datasource/blob/e175b02c9387ffc3ac926838c7318a0f1409eefe/src/types.ts#L54) and [Timestream](https://github.com/grafana/timestream-datasource/blob/d4ec8dfe49cbc328c5fae220e7258cd806e3bac3/src/components/QueryEditor.tsx#L33).

Closes: https://github.com/grafana/redshift-datasource/issues/383