### PR TITLE
Docs: remove outdated info from contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,12 +26,6 @@ Make sure you have the following dependencies installed first:
    yarn dev
    ```
 
-   or
-
-   ```bash
-   yarn watch
-   ```
-
 3. Build plugin in production mode
 
    ```bash

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "lint:fix": "yarn run lint --fix",
     "server": "docker compose up --build",
     "spellcheck": "cspell -c cspell.config.json \"**/*.{ts,tsx,js,go,md,mdx,yml,yaml,json,scss,css}\"",
-    "start": "yarn watch",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --passWithNoTests --maxWorkers 4",
     "test:coverage": "jest --coverage",


### PR DESCRIPTION
Fixes: https://github.com/grafana/redshift-datasource/issues/245

There's no `yarn watch` and we already have `yarn dev` so just removed `yarn watch` references.