### PR TITLE
Tweak dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,17 +31,6 @@ updates:
           - '@grafana/runtime'
           - '@grafana/schema'
           - '@grafana/ui'
-  - package-ecosystem: 'github-actions'
-    directory: '/'
-    schedule:
-      interval: 'daily'
-      time: '12:00'
-    open-pull-requests-limit: 3
-    cooldown:
-      default-days: 7
-      exclude:
-        - 'grafana/*'
-
     # Ignore dependencies that need to be updated manually for compatibility reasons
     ignore:
       # Keep @types/node in sync with the node version in .nvmrc
@@ -59,3 +48,13 @@ updates:
         update-types: ['version-update:semver-major']
       # Keep rxjs in sync with the version used by `@grafana/*` packages
       - dependency-name: rxjs
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+      time: '12:00'
+    open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7
+      exclude:
+        - 'grafana/*'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,24 +4,20 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+      time: '08:00'
+    open-pull-requests-limit: 3
     cooldown:
       semver-major-days: 30
       semver-minor-days: 14
       semver-patch-days: 7
       exclude:
         - 'github.com/grafana/*'
-  - package-ecosystem: 'github-actions'
-    directory: '/'
-    schedule:
-      interval: 'daily'
-    cooldown:
-      default-days: 7
-      exclude:
-        - 'grafana/*'
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
       interval: 'daily'
+      time: '10:00'
+    open-pull-requests-limit: 3
     cooldown:
       semver-major-days: 30
       semver-minor-days: 14
@@ -35,6 +31,16 @@ updates:
           - '@grafana/runtime'
           - '@grafana/schema'
           - '@grafana/ui'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+      time: '12:00'
+    open-pull-requests-limit: 3
+    cooldown:
+      default-days: 7
+      exclude:
+        - 'grafana/*'
 
     # Ignore dependencies that need to be updated manually for compatibility reasons
     ignore:


### PR DESCRIPTION
- Set the time when dependabot updates happen:
  - go updates at 8am UTC
  - npm updates at 10am UTC
  - github actions updates at 12pm UTC
- Limit the number of open PRs to 3 per package ecosystem
- Reordered the package ecosystems, moved `package-ecosystem: 'github-actions'` below `package-ecosystem: 'npm'`