### PR TITLE
revert skipping grafana dev image for e2e tests

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -41,7 +41,6 @@ jobs:
       scopes: ${{ github.event.inputs.environment == 'cloud (recommended)' && 'grafana_cloud' || github.event.inputs.environment == 'on-prem (for emergencies fix to On Prem customers)' && 'universal' }}
       go-version: '1.24'
       golangci-lint-version: '2.1.6'
-      run-playwright-with-skip-grafana-dev-image: true
       playwright-secrets: |
         ACCESS_KEY=e2e:accessKey
         SECRET_KEY=e2e:secretKey

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -18,7 +18,6 @@ jobs:
     with:
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
       golangci-lint-version: '2.1.6'
-      run-playwright-with-skip-grafana-dev-image: true
       playwright-secrets: |
         ACCESS_KEY=e2e:accessKey
         SECRET_KEY=e2e:secretKey


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/114273 fixed the issue where dev images of grafana would error when starting if the `provisioning/dashboards` folder was missing. this reenables using the dev grafana images in the e2e tests.