### PR TITLE
use platform automerge for renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>grafana/grafana-renovate-config//presets/automerge"],
   "minimumReleaseAge": "7 days",
-  "prConcurrentLimit": 3,
+  "platformAutomerge": true,
   "packageRules": [
     {
       "description": "Disable minimum release age for Grafana owned npm packages (@grafana/*)",
@@ -41,6 +41,12 @@
       "matchDatasources": ["npm"],
       "matchPackageNames": ["rxjs"],
       "enabled": false
+    },
+    {
+      "description": "Automerge minor dependencies",
+      "matchUpdateTypes": ["minor"],
+      "automerge": true,
+      "labels": ["automerge-minor"]
     }
   ]
 }


### PR DESCRIPTION
some updates to the renovate config:
- [`platformAutomerge` set to `true`](https://docs.renovatebot.com/configuration-options/#platformautomerge) to use GitHub's native automerge so PRs get merged when all required checks pass. Otherwise auto merging is done on a cron job that is run every 3 hours.
- Add a package rule to automerge minor dependencies. This is in addition to the preset `"github>grafana/grafana-renovate-config//presets/automerge"` which only automerges patch dependencies.
- Removed the `prConcurrentLimit` to let the default limit of 10 apply.