### PR TITLE
Add renovate branches to push workflow

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - renovate/*
   pull_request:
 
 permissions: {}


### PR DESCRIPTION
Adding in renovate to branch to CI checks target to test prCreation as in https://github.com/grafana/plugin-tools/pull/2383/files