### PR TITLE
Add renovate config to avoid early pr creation

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>grafana/grafana-renovate-config//presets/automerge"],
   "minimumReleaseAge": "7 days",
+  "prCreation": "not-pending",
+  "rebaseWhen": "conflicted",
   "platformAutomerge": true,
   "packageRules": [
     {


### PR DESCRIPTION
Follow up to https://github.com/grafana/redshift-datasource/pull/755
As part of https://github.com/grafana/deployment_tools/issues/438042

Adding renovate config to test Renovate adhering to minimum release age with ci checks against the repository