### PR TITLE
Bump grafana-aws-sdk-react and prepare 2.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.4.0
+
+- Add sessionToken handling to support Grafana Assume Role in [#795](https://github.com/grafana/redshift-datasource/pull/795)
+- fix(deps): update backend dependencies in [#791](https://github.com/grafana/redshift-datasource/pull/791)
+- chore(deps): pin grafana/grafana-enterprise docker tag to 582fc54 in [#789](https://github.com/grafana/redshift-datasource/pull/789)
+- chore(deps): update dependency @grafana/plugin-e2e to v3.4.3 in [#794](https://github.com/grafana/redshift-datasource/pull/794)
+- chore(deps): update actions/checkout digest to de0fac2 in [#786](https://github.com/grafana/redshift-datasource/pull/786)
+- chore(deps): pin dependencies in [#672](https://github.com/grafana/redshift-datasource/pull/672)
+- chore(deps): update actions/stale digest to b5d41d4 in [#787](https://github.com/grafana/redshift-datasource/pull/787)
+- chore(deps): update grafana/plugin-ci-workflows/ci-cd-workflows action to v6.1.1 in [#788](https://github.com/grafana/redshift-datasource/pull/788)
+- chore(deps): update dependency @grafana/plugin-e2e to v3.4.2 in [#783](https://github.com/grafana/redshift-datasource/pull/783)
+- Update renovate config to use data-sources base preset in [#785](https://github.com/grafana/redshift-datasource/pull/785)
+
 ## 2.3.4
 
 - fix(deps): update go patch updates in [#770](https://github.com/grafana/redshift-datasource/pull/770)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-redshift-datasource",
-  "version": "2.3.4",
+  "version": "2.4.0",
   "description": "Use Amazon Redshift in Grafana",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@babel/core": "7.28.5",
     "@eslint/eslintrc": "3.3.1",
     "@eslint/js": "9.39.2",
-    "@grafana/aws-sdk": "0.10.1",
+    "@grafana/aws-sdk": "0.10.2",
     "@grafana/eslint-config": "9.0.0",
     "@grafana/plugin-e2e": "3.4.5",
     "@grafana/tsconfig": "2.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1470,13 +1470,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/aws-sdk@npm:0.10.1":
-  version: 0.10.1
-  resolution: "@grafana/aws-sdk@npm:0.10.1"
+"@grafana/aws-sdk@npm:0.10.2":
+  version: 0.10.2
+  resolution: "@grafana/aws-sdk@npm:0.10.2"
   dependencies:
     "@grafana/async-query-data": "npm:0.4.2"
     "@grafana/plugin-ui": "npm:^0.13.0"
-  checksum: 10c0/38f42bd613bc21aef479372cb104223edc1ed681ae47a61e1bdea866dea5647a73f4891b5abe3e6e005d9ad8c3b8b3ebaff5195529dd71f9ceb6c437fa0b3ea3
+  checksum: 10c0/de9809075c52853441a6e46b21681e83b38099ac1ee70272d8f1397262fd3ea495b1fa898c8df7a29a70c46a97cc6bf614a2283e3a78aba3be4f6000d852e382
   languageName: node
   linkType: hard
 
@@ -1617,8 +1617,8 @@ __metadata:
   linkType: hard
 
 "@grafana/plugin-ui@npm:^0.13.0":
-  version: 0.13.1
-  resolution: "@grafana/plugin-ui@npm:0.13.1"
+  version: 0.13.0
+  resolution: "@grafana/plugin-ui@npm:0.13.0"
   dependencies:
     "@emotion/css": "npm:^11.11.2"
     "@hello-pangea/dnd": "npm:^17.0.0"
@@ -1644,7 +1644,7 @@ __metadata:
     react: ^18.2.0
     react-dom: ^18.2.0
     rxjs: ^7.8.1
-  checksum: 10c0/a44bf6e9ad3f3d5987005ebe8401cd148b7f2eaee29e9644b635a697afc4f6dc10b7e0520b549aad6f640bcb8d04659835e295731e5e9a873a60137eec7e9121
+  checksum: 10c0/7aaf5787cde1f6d6670fdb453e651a2cc9d782114c12f17b580b91eddf78111ee5edfe6f9b69fda86cdfa4d10617730666fe7edbd7c0b9ba3172e6f58cb10281
   languageName: node
   linkType: hard
 
@@ -7505,7 +7505,7 @@ __metadata:
     "@eslint/eslintrc": "npm:3.3.1"
     "@eslint/js": "npm:9.39.2"
     "@grafana/async-query-data": "npm:0.4.2"
-    "@grafana/aws-sdk": "npm:0.10.1"
+    "@grafana/aws-sdk": "npm:0.10.2"
     "@grafana/data": "npm:12.4.1"
     "@grafana/eslint-config": "npm:9.0.0"
     "@grafana/plugin-e2e": "npm:3.4.5"
@@ -11545,7 +11545,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.5, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.6.3, semver@npm:^7.7.0, semver@npm:^7.7.2, semver@npm:^7.7.3, semver@npm:^7.7.4":
+"semver@npm:^7.3.5, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.6.3, semver@npm:^7.7.0, semver@npm:^7.7.2, semver@npm:^7.7.3":
+  version: 7.7.3
+  resolution: "semver@npm:7.7.3"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/4afe5c986567db82f44c8c6faef8fe9df2a9b1d98098fc1721f57c696c4c21cebd572f297fc21002f81889492345b8470473bc6f4aff5fb032a6ea59ea2bc45e
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.7.4":
   version: 7.7.4
   resolution: "semver@npm:7.7.4"
   bin:


### PR DESCRIPTION
## Summary
- Bump `@grafana/aws-sdk` to 0.10.2
- Bump version to 2.4.0 and update CHANGELOG.md with all changes since 2.3.4