### PR TITLE
docs: add signed commits requirement to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,10 @@
+# Contributing
+
+## Signed commits are required
+
+> [!IMPORTANT]
+> All commits must be [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (GPG, SSH, or S/MIME) to be merged into this repository. Pull requests with unsigned commits will need to be re-committed with signatures before they can be merged.
+
 # Building and releasing
 
 ## How to build the Redshift data source plugin locally

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@grafana/aws-sdk": "0.10.2",
     "@grafana/eslint-config": "9.0.0",
     "@grafana/levitate": "0.17.2",
-    "@grafana/plugin-e2e": "3.9.1",
+    "@grafana/plugin-e2e": "3.9.2",
     "@grafana/sign-plugin": "3.2.2",
     "@grafana/tsconfig": "2.0.1",
     "@openfeature/core": "1.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1826,9 +1826,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grafana/plugin-e2e@npm:3.9.1":
-  version: 3.9.1
-  resolution: "@grafana/plugin-e2e@npm:3.9.1"
+"@grafana/plugin-e2e@npm:3.9.2":
+  version: 3.9.2
+  resolution: "@grafana/plugin-e2e@npm:3.9.2"
   dependencies:
     "@grafana/e2e-selectors": "npm:13.1.0-25644485979"
     yaml: "npm:^2.3.4"
@@ -1838,7 +1838,7 @@ __metadata:
   peerDependenciesMeta:
     "@axe-core/playwright":
       optional: true
-  checksum: 10c0/93e17213c8a63f52a08cdb2716ea5a1a799b435a14e4bc2ce8fbc710a3afa03e54aa097f4d81b1f452c659867aad0fe475f861aa8523f74790216f18bee528ba
+  checksum: 10c0/6dbdf6bd966034ce074835c5816e7d4e483110493875d97907a65b7d0d9229a40ed1601c12e02b6bfacc1c300c8319299c9db50e7a219824721cd80f0b26de40
   languageName: node
   linkType: hard
 
@@ -7976,7 +7976,7 @@ __metadata:
     "@grafana/data": "npm:13.1.0"
     "@grafana/eslint-config": "npm:9.0.0"
     "@grafana/levitate": "npm:0.17.2"
-    "@grafana/plugin-e2e": "npm:3.9.1"
+    "@grafana/plugin-e2e": "npm:3.9.2"
     "@grafana/plugin-ui": "npm:^0.13.0"
     "@grafana/runtime": "npm:13.1.0"
     "@grafana/schema": "npm:13.1.0"


### PR DESCRIPTION
## Summary

- Adds a highly visible callout at the top of `CONTRIBUTING.md` stating that signed commits (GPG, SSH, or S/MIME) are required to merge into this repository, per the recent policy change
- Uses GitHub's `[!IMPORTANT]` alert syntax so it renders as a highlighted callout, and links to GitHub's signed-commits docs.

## Checks

- `prettier --check CONTRIBUTING.md` passes.
